### PR TITLE
Implement FEN parsing and add board tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(SirioC LANGUAGES CXX)
 option(ENABLE_LTO "Enable link-time optimization" ON)
 option(ENABLE_AVX2 "Enable AVX2 where available" ON)
 
+enable_testing()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -48,3 +50,11 @@ target_compile_definitions(SirioC PRIVATE
   ENGINE_NAME=\"SirioC\"
   ENGINE_VERSION=\"0.1.0\"
 )
+
+add_executable(SirioCTests
+  tests/board_fen_tests.cpp
+  src/core/board.cpp
+  src/core/fen.cpp
+)
+
+add_test(NAME board_fen_tests COMMAND SirioCTests)

--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -1,5 +1,8 @@
 #pragma once
+#include <array>
+#include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 #include "engine/types.hpp"
 
@@ -7,6 +10,40 @@ namespace engine {
 
 class Board {
 public:
+    enum PieceIndex : int {
+        WHITE_PAWN = 0,
+        WHITE_KNIGHT,
+        WHITE_BISHOP,
+        WHITE_ROOK,
+        WHITE_QUEEN,
+        WHITE_KING,
+        BLACK_PAWN,
+        BLACK_KNIGHT,
+        BLACK_BISHOP,
+        BLACK_ROOK,
+        BLACK_QUEEN,
+        BLACK_KING,
+        PIECE_NB
+    };
+
+    enum OccupancyIndex : int {
+        OCC_WHITE = 0,
+        OCC_BLACK,
+        OCC_BOTH,
+        OCC_NB
+    };
+
+    enum CastlingRight : uint8_t {
+        CASTLE_WHITE_KINGSIDE  = 1u << 0,
+        CASTLE_WHITE_QUEENSIDE = 1u << 1,
+        CASTLE_BLACK_KINGSIDE  = 1u << 2,
+        CASTLE_BLACK_QUEENSIDE = 1u << 3
+    };
+
+    static constexpr int INVALID_SQUARE = -1;
+    static constexpr std::string_view kStartposFEN =
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
     Board();
     void set_startpos();
     bool set_fen(const std::string& fen);
@@ -19,9 +56,23 @@ public:
     // Accessors
     bool white_to_move() const { return stm_white_; }
     const std::string& last_fen() const { return last_fen_; }
+    const std::array<uint64_t, PIECE_NB>& piece_bitboards() const { return piece_bitboards_; }
+    const std::array<uint64_t, OCC_NB>& occupancy() const { return occupancy_; }
+    char piece_on(int square) const { return board_[square]; }
+    uint8_t castling_rights() const { return castling_rights_; }
+    int en_passant_square() const { return en_passant_square_; }
+    int halfmove_clock() const { return halfmove_clock_; }
+    int fullmove_number() const { return fullmove_number_; }
 
 private:
     bool stm_white_ = true;
+    std::array<uint64_t, PIECE_NB> piece_bitboards_{};
+    std::array<uint64_t, OCC_NB> occupancy_{};
+    std::array<char, 64> board_{};
+    uint8_t castling_rights_ = 0;
+    int en_passant_square_ = INVALID_SQUARE;
+    int halfmove_clock_ = 0;
+    int fullmove_number_ = 1;
     std::string last_fen_;
 };
 

--- a/src/core/board.cpp
+++ b/src/core/board.cpp
@@ -1,25 +1,182 @@
 #include "engine/core/board.hpp"
 #include "engine/core/fen.hpp"
+#include <array>
+#include <cctype>
+#include <charconv>
 #include <sstream>
 
 namespace engine {
 
+namespace {
+
+constexpr uint64_t kSquareMask(int square) { return 1ULL << square; }
+
+int piece_index_from_char(char c) {
+    switch (c) {
+    case 'P': return Board::WHITE_PAWN;
+    case 'N': return Board::WHITE_KNIGHT;
+    case 'B': return Board::WHITE_BISHOP;
+    case 'R': return Board::WHITE_ROOK;
+    case 'Q': return Board::WHITE_QUEEN;
+    case 'K': return Board::WHITE_KING;
+    case 'p': return Board::BLACK_PAWN;
+    case 'n': return Board::BLACK_KNIGHT;
+    case 'b': return Board::BLACK_BISHOP;
+    case 'r': return Board::BLACK_ROOK;
+    case 'q': return Board::BLACK_QUEEN;
+    case 'k': return Board::BLACK_KING;
+    default: return -1;
+    }
+}
+
+bool parse_int(const std::string& token, int min_value, int& out) {
+    int value = 0;
+    auto first = token.data();
+    auto last = token.data() + token.size();
+    auto res = std::from_chars(first, last, value);
+    if (res.ec != std::errc() || res.ptr != last) return false;
+    if (value < min_value) return false;
+    out = value;
+    return true;
+}
+
+int square_from_algebraic(const std::string& alg) {
+    if (alg.size() != 2) return Board::INVALID_SQUARE;
+    char file = alg[0];
+    char rank = alg[1];
+    if (file < 'a' || file > 'h') return Board::INVALID_SQUARE;
+    if (rank < '1' || rank > '8') return Board::INVALID_SQUARE;
+    int file_idx = file - 'a';
+    int rank_idx = rank - '1';
+    return rank_idx * 8 + file_idx;
+}
+
+bool parse_board_field(const std::string& field,
+                       std::array<uint64_t, Board::PIECE_NB>& piece_bb,
+                       std::array<uint64_t, Board::OCC_NB>& occupancy,
+                       std::array<char, 64>& board_array) {
+    piece_bb.fill(0ULL);
+    occupancy.fill(0ULL);
+    board_array.fill('.');
+
+    int rank = 7;
+    int file = 0;
+    uint64_t white_occ = 0ULL;
+    uint64_t black_occ = 0ULL;
+
+    for (char c : field) {
+        if (c == '/') {
+            if (file != 8 || rank == 0) return false;
+            --rank;
+            file = 0;
+            continue;
+        }
+
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            int skip = c - '0';
+            if (skip < 1 || skip > 8 || file + skip > 8) return false;
+            file += skip;
+            continue;
+        }
+
+        int piece_index = piece_index_from_char(c);
+        if (piece_index == -1 || file >= 8) return false;
+
+        int square = rank * 8 + file;
+        uint64_t mask = kSquareMask(square);
+        piece_bb[static_cast<size_t>(piece_index)] |= mask;
+        if (piece_index <= Board::WHITE_KING) {
+            white_occ |= mask;
+        } else {
+            black_occ |= mask;
+        }
+        board_array[static_cast<size_t>(square)] = c;
+        ++file;
+    }
+
+    if (rank != 0 || file != 8) return false;
+
+    occupancy[Board::OCC_WHITE] = white_occ;
+    occupancy[Board::OCC_BLACK] = black_occ;
+    occupancy[Board::OCC_BOTH] = white_occ | black_occ;
+    return true;
+}
+
+bool parse_castling_field(const std::string& field, uint8_t& rights) {
+    rights = 0;
+    if (field == "-") return true;
+    for (char c : field) {
+        uint8_t mask = 0;
+        switch (c) {
+        case 'K': mask = Board::CASTLE_WHITE_KINGSIDE; break;
+        case 'Q': mask = Board::CASTLE_WHITE_QUEENSIDE; break;
+        case 'k': mask = Board::CASTLE_BLACK_KINGSIDE; break;
+        case 'q': mask = Board::CASTLE_BLACK_QUEENSIDE; break;
+        default: return false;
+        }
+        if (rights & mask) return false;
+        rights |= mask;
+    }
+    return true;
+}
+
+bool parse_en_passant_field(const std::string& field, int& square) {
+    if (field == "-") {
+        square = Board::INVALID_SQUARE;
+        return true;
+    }
+    square = square_from_algebraic(field);
+    if (square == Board::INVALID_SQUARE) return false;
+    return true;
+}
+
+} // namespace
+
 Board::Board() { set_startpos(); }
 
 void Board::set_startpos() {
-    // Standard FEN
-    last_fen_ = "rnbrqkbn/pppppppp/8/8/8/8/PPPPPPPP/RNBRQKBN w KQkq - 0 1"; // placeholder FEN to avoid accidental deps
-    // TODO: replace with correct initial FEN:
-    last_fen_ = "rn1qkbnr/pppbpppp/8/3p4/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 3"; // temporary
-    // For now, track side-to-move from fen validator later
-    stm_white_ = true;
+    (void)set_fen(std::string(kStartposFEN));
 }
 
 bool Board::set_fen(const std::string& fen) {
     if (!fen::is_valid_fen(fen)) return false;
+    std::istringstream iss(fen);
+    std::string board_field, stm_field, castling_field, ep_field, halfmove_field, fullmove_field;
+    if (!(iss >> board_field >> stm_field >> castling_field >> ep_field >> halfmove_field >> fullmove_field)) {
+        return false;
+    }
+    std::string extra;
+    if (iss >> extra) return false;
+
+    std::array<uint64_t, PIECE_NB> piece_bb{};
+    std::array<uint64_t, OCC_NB> occupancy{};
+    std::array<char, 64> board_array{};
+    uint8_t castling = 0;
+    int ep_square = INVALID_SQUARE;
+    int halfmove = 0;
+    int fullmove = 1;
+    bool stm_white = false;
+
+    if (!parse_board_field(board_field, piece_bb, occupancy, board_array)) return false;
+
+    if (stm_field == "w") stm_white = true;
+    else if (stm_field == "b") stm_white = false;
+    else return false;
+
+    if (!parse_castling_field(castling_field, castling)) return false;
+    if (!parse_en_passant_field(ep_field, ep_square)) return false;
+    if (!parse_int(halfmove_field, 0, halfmove)) return false;
+    if (!parse_int(fullmove_field, 1, fullmove)) return false;
+
+    piece_bitboards_ = piece_bb;
+    occupancy_ = occupancy;
+    board_ = board_array;
+    castling_rights_ = castling;
+    en_passant_square_ = ep_square;
+    halfmove_clock_ = halfmove;
+    fullmove_number_ = fullmove;
+    stm_white_ = stm_white;
     last_fen_ = fen;
-    // TODO: parse into bitboards, castling, ep, etc.
-    // set stm_white_ properly
     return true;
 }
 

--- a/src/core/fen.cpp
+++ b/src/core/fen.cpp
@@ -1,9 +1,30 @@
 #include "engine/core/fen.hpp"
+#include "engine/core/board.hpp"
+#include <cctype>
+#include <charconv>
 #include <sstream>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace engine { namespace fen {
+
+static int piece_index_from_char(char c) {
+    switch (c) {
+    case 'P': return Board::WHITE_PAWN;
+    case 'N': return Board::WHITE_KNIGHT;
+    case 'B': return Board::WHITE_BISHOP;
+    case 'R': return Board::WHITE_ROOK;
+    case 'Q': return Board::WHITE_QUEEN;
+    case 'K': return Board::WHITE_KING;
+    case 'p': return Board::BLACK_PAWN;
+    case 'n': return Board::BLACK_KNIGHT;
+    case 'b': return Board::BLACK_BISHOP;
+    case 'r': return Board::BLACK_ROOK;
+    case 'q': return Board::BLACK_QUEEN;
+    case 'k': return Board::BLACK_KING;
+    default: return -1;
+    }
+}
 
 static inline std::vector<std::string> split(const std::string& s) {
     std::istringstream iss(s);
@@ -12,10 +33,76 @@ static inline std::vector<std::string> split(const std::string& s) {
     return out;
 }
 
+static bool parse_int(const std::string& token, int min_value) {
+    int value = 0;
+    auto first = token.data();
+    auto last = token.data() + token.size();
+    auto res = std::from_chars(first, last, value);
+    if (res.ec != std::errc() || res.ptr != last) return false;
+    return value >= min_value;
+}
+
+static bool validate_board_field(const std::string& board_field) {
+    int rank = 7;
+    int file = 0;
+    for (char c : board_field) {
+        if (c == '/') {
+            if (file != 8 || rank == 0) return false;
+            --rank;
+            file = 0;
+            continue;
+        }
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            int skip = c - '0';
+            if (skip < 1 || skip > 8 || file + skip > 8) return false;
+            file += skip;
+            continue;
+        }
+        if (piece_index_from_char(c) == -1 || file >= 8) return false;
+        ++file;
+    }
+    return rank == 0 && file == 8;
+}
+
+static bool validate_castling(const std::string& field) {
+    if (field == "-") return true;
+    uint8_t rights = 0;
+    for (char c : field) {
+        uint8_t mask = 0;
+        switch (c) {
+        case 'K': mask = Board::CASTLE_WHITE_KINGSIDE; break;
+        case 'Q': mask = Board::CASTLE_WHITE_QUEENSIDE; break;
+        case 'k': mask = Board::CASTLE_BLACK_KINGSIDE; break;
+        case 'q': mask = Board::CASTLE_BLACK_QUEENSIDE; break;
+        default: return false;
+        }
+        if (rights & mask) return false;
+        rights |= mask;
+    }
+    return true;
+}
+
+static bool validate_en_passant(const std::string& field) {
+    if (field == "-") return true;
+    if (field.size() != 2) return false;
+    char file = field[0];
+    char rank = field[1];
+    if (file < 'a' || file > 'h') return false;
+    if (rank < '1' || rank > '8') return false;
+    return true;
+}
+
 bool is_valid_fen(const std::string& fen) {
     auto t = split(fen);
-    // Very loose validation: 6 fields expected
-    return t.size() >= 4;
+    if (t.size() != 6) return false;
+
+    if (!validate_board_field(t[0])) return false;
+    if (t[1] != "w" && t[1] != "b") return false;
+    if (!validate_castling(t[2])) return false;
+    if (!validate_en_passant(t[3])) return false;
+    if (!parse_int(t[4], 0)) return false;
+    if (!parse_int(t[5], 1)) return false;
+    return true;
 }
 
 }} // namespace

--- a/tests/board_fen_tests.cpp
+++ b/tests/board_fen_tests.cpp
@@ -1,0 +1,48 @@
+#include "engine/core/board.hpp"
+#include "engine/core/fen.hpp"
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+using namespace engine;
+
+static uint64_t bitboard_for_square(char file, char rank) {
+    int file_idx = file - 'a';
+    int rank_idx = rank - '1';
+    return 1ULL << (rank_idx * 8 + file_idx);
+}
+
+int main() {
+    Board board;
+    assert(board.last_fen() == Board::kStartposFEN);
+    assert(board.white_to_move());
+    assert(board.castling_rights() == (Board::CASTLE_WHITE_KINGSIDE |
+                                       Board::CASTLE_WHITE_QUEENSIDE |
+                                       Board::CASTLE_BLACK_KINGSIDE |
+                                       Board::CASTLE_BLACK_QUEENSIDE));
+    assert(board.en_passant_square() == Board::INVALID_SQUARE);
+    assert(board.halfmove_clock() == 0);
+    assert(board.fullmove_number() == 1);
+
+    const auto& bb = board.piece_bitboards();
+    assert(bb[Board::WHITE_PAWN] == 0x000000000000FF00ULL);
+    assert(bb[Board::BLACK_PAWN] == 0x00FF000000000000ULL);
+    assert(bb[Board::WHITE_KING] == bitboard_for_square('e', '1'));
+    assert(bb[Board::BLACK_KING] == bitboard_for_square('e', '8'));
+
+    std::string fen = "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+    assert(fen::is_valid_fen(fen));
+    assert(board.set_fen(fen));
+    assert(!board.white_to_move());
+    assert(board.en_passant_square() == 20); // e3
+    assert(board.halfmove_clock() == 0);
+    assert(board.fullmove_number() == 1);
+    assert(board.piece_on(28) == 'P'); // e4
+
+    std::string bad_fen = "8/8/8/8/8/8/8/8 w - -";
+    assert(!fen::is_valid_fen(bad_fen));
+
+    std::cout << "All Board FEN tests passed.\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace the placeholder start position FEN with the official opening FEN and expand the board state to track bitboards, castling rights, en passant and move counters
- implement full FEN parsing and validation routines to initialize the expanded board state
- add a simple CMake-driven test target that exercises the start position and a custom FEN

## Testing
- ctest

------
https://chatgpt.com/codex/tasks/task_e_68d76e045af8832792dc731f29229abc