### PR TITLE
Implement basic move generation and go command test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,13 +38,30 @@ file(GLOB_RECURSE SRC_FILES
   src/*.cpp
 )
 
-add_executable(SirioC ${SRC_FILES})
+set(MAIN_SOURCE ${CMAKE_SOURCE_DIR}/src/main.cpp)
+list(REMOVE_ITEM SRC_FILES ${MAIN_SOURCE})
 
-if (MINGW)
-  target_link_libraries(SirioC PRIVATE stdc++ stdc++fs)
-endif()
-
-target_compile_definitions(SirioC PRIVATE
+add_library(sirio_core ${SRC_FILES})
+target_compile_definitions(sirio_core PUBLIC
   ENGINE_NAME=\"SirioC\"
   ENGINE_VERSION=\"0.1.0\"
 )
+
+add_executable(SirioC ${MAIN_SOURCE})
+target_link_libraries(SirioC PRIVATE sirio_core)
+
+add_executable(legal_moves_cli tests/legal_moves_cli.cpp)
+target_link_libraries(legal_moves_cli PRIVATE sirio_core)
+
+if (MINGW)
+  target_link_libraries(SirioC PRIVATE stdc++ stdc++fs)
+  target_link_libraries(legal_moves_cli PRIVATE stdc++ stdc++fs)
+endif()
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+enable_testing()
+add_test(NAME go_command_responds_with_legal_move
+         COMMAND Python3::Interpreter
+                 ${CMAKE_SOURCE_DIR}/tests/test_go.py
+                 $<TARGET_FILE:SirioC>
+                 $<TARGET_FILE:legal_moves_cli>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,13 +53,18 @@ target_link_libraries(SirioC PRIVATE sirio_core)
 add_executable(legal_moves_cli tests/legal_moves_cli.cpp)
 target_link_libraries(legal_moves_cli PRIVATE sirio_core)
 
+add_executable(movegen_tests tests/movegen_tests.cpp)
+target_link_libraries(movegen_tests PRIVATE sirio_core)
+
 if (MINGW)
   target_link_libraries(SirioC PRIVATE stdc++ stdc++fs)
   target_link_libraries(legal_moves_cli PRIVATE stdc++ stdc++fs)
+  target_link_libraries(movegen_tests PRIVATE stdc++ stdc++fs)
 endif()
 
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 enable_testing()
+add_test(NAME movegen_unit_tests COMMAND movegen_tests)
 add_test(NAME go_command_responds_with_legal_move
          COMMAND Python3::Interpreter
                  ${CMAKE_SOURCE_DIR}/tests/test_go.py

--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <string>
 #include <vector>
 #include "engine/types.hpp"
@@ -12,17 +13,48 @@ public:
     bool set_fen(const std::string& fen);
     bool apply_moves_uci(const std::vector<std::string>& uci_moves);
 
-    // TODO: move generation and make/unmake hooks
-    // bool make_move(Move m);
-    // void unmake_move();
+    bool make_move(Move m);
+    bool make_move_uci(const std::string& uci);
+    std::vector<Move> generate_legal_moves() const;
+    std::string move_to_uci(Move move) const;
 
     // Accessors
     bool white_to_move() const { return stm_white_; }
     const std::string& last_fen() const { return last_fen_; }
 
 private:
+    enum Castling : uint8_t {
+        CASTLE_WHITE_K = 1 << 0,
+        CASTLE_WHITE_Q = 1 << 1,
+        CASTLE_BLACK_K = 1 << 2,
+        CASTLE_BLACK_Q = 1 << 3,
+    };
+
+    void generate_pseudo_legal_moves(std::vector<Move>& moves) const;
+    void generate_pawn_moves(int sq, std::vector<Move>& moves) const;
+    void generate_knight_moves(int sq, std::vector<Move>& moves) const;
+    void generate_bishop_moves(int sq, std::vector<Move>& moves) const;
+    void generate_rook_moves(int sq, std::vector<Move>& moves) const;
+    void generate_queen_moves(int sq, std::vector<Move>& moves) const;
+    void generate_king_moves(int sq, std::vector<Move>& moves) const;
+    bool in_check(bool white) const;
+    bool is_square_attacked(int sq, bool by_white) const;
+    int find_king_square(bool white) const;
+    void do_move(Move move);
+    static bool is_white_piece(char piece);
+    static bool is_black_piece(char piece);
+    static bool is_empty(char piece);
+    static int file_of(int sq);
+    static int rank_of(int sq);
+    static int to_index(int file, int rank);
+    std::string square_to_string(int sq) const;
+    char promotion_from_code(int code, bool white) const;
+
     bool stm_white_ = true;
     std::string last_fen_;
+    std::array<char, 64> squares_{};
+    uint8_t castling_rights_ = 0;
+    int en_passant_square_ = -1;
 };
 
 } // namespace engine

--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <array>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "engine/types.hpp"

--- a/include/engine/types.hpp
+++ b/include/engine/types.hpp
@@ -5,8 +5,44 @@
 
 namespace engine {
 
-using Move = uint32_t; // TODO: encode from,to,promo,flags
+using Move = uint32_t; // Encode from/to squares, promotion, flags
 constexpr Move MOVE_NONE = 0;
+
+constexpr int MOVE_FROM_SHIFT = 0;
+constexpr int MOVE_TO_SHIFT = 6;
+constexpr int MOVE_PROMO_SHIFT = 12;
+constexpr Move MOVE_PROMO_MASK = 0b111u << MOVE_PROMO_SHIFT;
+
+constexpr Move MOVE_FLAG_CAPTURE = 1u << 15;
+constexpr Move MOVE_FLAG_DOUBLE_PAWN = 1u << 16;
+constexpr Move MOVE_FLAG_ENPASSANT = 1u << 17;
+constexpr Move MOVE_FLAG_CASTLING = 1u << 18;
+
+constexpr Move make_move(int from, int to, int promo = 0, bool capture = false,
+                         bool double_pawn = false, bool enpassant = false,
+                         bool castling = false) {
+    return (static_cast<Move>(from & 63) << MOVE_FROM_SHIFT) |
+           (static_cast<Move>(to & 63) << MOVE_TO_SHIFT) |
+           (static_cast<Move>(promo & 7) << MOVE_PROMO_SHIFT) |
+           (capture ? MOVE_FLAG_CAPTURE : 0) |
+           (double_pawn ? MOVE_FLAG_DOUBLE_PAWN : 0) |
+           (enpassant ? MOVE_FLAG_ENPASSANT : 0) |
+           (castling ? MOVE_FLAG_CASTLING : 0);
+}
+
+constexpr int move_from(Move m) { return (m >> MOVE_FROM_SHIFT) & 63; }
+constexpr int move_to(Move m) { return (m >> MOVE_TO_SHIFT) & 63; }
+constexpr int move_promo(Move m) { return (m >> MOVE_PROMO_SHIFT) & 7; }
+constexpr bool move_is_capture(Move m) { return (m & MOVE_FLAG_CAPTURE) != 0; }
+constexpr bool move_is_double_pawn(Move m) {
+    return (m & MOVE_FLAG_DOUBLE_PAWN) != 0;
+}
+constexpr bool move_is_enpassant(Move m) {
+    return (m & MOVE_FLAG_ENPASSANT) != 0;
+}
+constexpr bool move_is_castling(Move m) {
+    return (m & MOVE_FLAG_CASTLING) != 0;
+}
 
 struct Limits {
     int32_t depth = 64;

--- a/src/core/board.cpp
+++ b/src/core/board.cpp
@@ -1,31 +1,169 @@
 #include "engine/core/board.hpp"
 #include "engine/core/fen.hpp"
+#include <algorithm>
+#include <array>
+#include <cctype>
 #include <sstream>
+#include <vector>
 
 namespace engine {
 
 Board::Board() { set_startpos(); }
 
 void Board::set_startpos() {
-    // Standard FEN
-    last_fen_ = "rnbrqkbn/pppppppp/8/8/8/8/PPPPPPPP/RNBRQKBN w KQkq - 0 1"; // placeholder FEN to avoid accidental deps
-    // TODO: replace with correct initial FEN:
-    last_fen_ = "rn1qkbnr/pppbpppp/8/3p4/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 3"; // temporary
-    // For now, track side-to-move from fen validator later
-    stm_white_ = true;
+    set_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
 }
 
 bool Board::set_fen(const std::string& fen) {
     if (!fen::is_valid_fen(fen)) return false;
+    std::istringstream iss(fen);
+    std::vector<std::string> tokens;
+    std::string tok;
+    while (iss >> tok) tokens.push_back(tok);
+    if (tokens.size() < 4) return false;
+
+    std::array<char, 64> new_squares;
+    std::fill(new_squares.begin(), new_squares.end(), '.');
+    bool new_stm_white = tokens[1] == "w";
+    uint8_t new_castling = 0;
+    int new_en_passant = -1;
+
+    int rank = 7;
+    int file = 0;
+    for (char c : tokens[0]) {
+        if (c == '/') {
+            if (file != 8) return false;
+            --rank;
+            if (rank < 0) return false;
+            file = 0;
+            continue;
+        }
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            file += c - '0';
+        } else {
+            if (file >= 8 || rank < 0) return false;
+            new_squares[rank * 8 + file] = c;
+            ++file;
+        }
+    }
+    if (rank != 0 || file != 8) {
+        return false;
+    }
+
+    if (tokens[2] != "-") {
+        for (char c : tokens[2]) {
+            switch (c) {
+                case 'K': new_castling |= CASTLE_WHITE_K; break;
+                case 'Q': new_castling |= CASTLE_WHITE_Q; break;
+                case 'k': new_castling |= CASTLE_BLACK_K; break;
+                case 'q': new_castling |= CASTLE_BLACK_Q; break;
+                default: break;
+            }
+        }
+    }
+
+    if (tokens[3] != "-") {
+        if (tokens[3].size() == 2) {
+            char file_char = tokens[3][0];
+            char rank_char = tokens[3][1];
+            if (file_char >= 'a' && file_char <= 'h' && rank_char >= '1' && rank_char <= '8') {
+                new_en_passant = (rank_char - '1') * 8 + (file_char - 'a');
+            }
+        }
+    }
+
+    squares_ = new_squares;
+    stm_white_ = new_stm_white;
+    castling_rights_ = new_castling;
+    en_passant_square_ = new_en_passant;
     last_fen_ = fen;
-    // TODO: parse into bitboards, castling, ep, etc.
-    // set stm_white_ properly
     return true;
 }
 
-bool Board::apply_moves_uci(const std::vector<std::string>& /*uci_moves*/) {
-    // TODO: translate UCI strings to Move, call make_move
+bool Board::apply_moves_uci(const std::vector<std::string>& uci_moves) {
+    for (const auto& uci : uci_moves) {
+        if (!make_move_uci(uci)) return false;
+    }
     return true;
+}
+
+bool Board::make_move(Move move) {
+    auto legal = generate_legal_moves();
+    for (Move m : legal) {
+        if (m == move) {
+            do_move(m);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Board::make_move_uci(const std::string& uci) {
+    auto legal = generate_legal_moves();
+    for (Move m : legal) {
+        if (move_to_uci(m) == uci) {
+            do_move(m);
+            return true;
+        }
+    }
+    return false;
+}
+
+std::string Board::move_to_uci(Move move) const {
+    if (move == MOVE_NONE) return "0000";
+    std::string out;
+    out.reserve(5);
+    out += square_to_string(move_from(move));
+    out += square_to_string(move_to(move));
+    int promo = move_promo(move);
+    if (promo) {
+        static const char promo_chars[] = {' ', 'n', 'b', 'r', 'q'};
+        if (promo >= 0 && promo < static_cast<int>(sizeof(promo_chars) / sizeof(promo_chars[0]))) {
+            out.push_back(promo_chars[promo]);
+        }
+    }
+    return out;
+}
+
+bool Board::is_white_piece(char piece) {
+    return piece >= 'A' && piece <= 'Z';
+}
+
+bool Board::is_black_piece(char piece) {
+    return piece >= 'a' && piece <= 'z';
+}
+
+bool Board::is_empty(char piece) {
+    return piece == '.';
+}
+
+int Board::file_of(int sq) {
+    return sq % 8;
+}
+
+int Board::rank_of(int sq) {
+    return sq / 8;
+}
+
+int Board::to_index(int file, int rank) {
+    return rank * 8 + file;
+}
+
+std::string Board::square_to_string(int sq) const {
+    std::string s;
+    s.push_back(static_cast<char>('a' + file_of(sq)));
+    s.push_back(static_cast<char>('1' + rank_of(sq)));
+    return s;
+}
+
+char Board::promotion_from_code(int code, bool white) const {
+    switch (code) {
+        case 1: return white ? 'N' : 'n';
+        case 2: return white ? 'B' : 'b';
+        case 3: return white ? 'R' : 'r';
+        case 4: return white ? 'Q' : 'q';
+        default: return white ? 'P' : 'p';
+    }
 }
 
 } // namespace engine

--- a/src/core/movegen.cpp
+++ b/src/core/movegen.cpp
@@ -1,0 +1,418 @@
+#include "engine/core/board.hpp"
+#include <cctype>
+
+namespace engine {
+
+namespace {
+constexpr int knight_offsets[8][2] = {
+    {1, 2}, {2, 1}, {2, -1}, {1, -2},
+    {-1, -2}, {-2, -1}, {-2, 1}, {-1, 2},
+};
+
+constexpr int king_offsets[8][2] = {
+    {1, 0},  {1, 1},  {0, 1},  {-1, 1},
+    {-1, 0}, {-1, -1}, {0, -1}, {1, -1},
+};
+
+constexpr int bishop_dirs[4][2] = {
+    {1, 1},  {1, -1},
+    {-1, 1}, {-1, -1},
+};
+
+constexpr int rook_dirs[4][2] = {
+    {1, 0},  {0, 1},
+    {-1, 0}, {0, -1},
+};
+
+inline bool on_board(int file, int rank) {
+    return file >= 0 && file < 8 && rank >= 0 && rank < 8;
+}
+
+} // namespace
+
+std::vector<Move> Board::generate_legal_moves() const {
+    std::vector<Move> pseudo;
+    generate_pseudo_legal_moves(pseudo);
+    std::vector<Move> legal;
+    legal.reserve(pseudo.size());
+    bool moving_white = stm_white_;
+    for (Move m : pseudo) {
+        Board copy(*this);
+        copy.do_move(m);
+        if (!copy.in_check(moving_white)) {
+            legal.push_back(m);
+        }
+    }
+    return legal;
+}
+
+void Board::generate_pseudo_legal_moves(std::vector<Move>& moves) const {
+    for (int sq = 0; sq < 64; ++sq) {
+        char piece = squares_[sq];
+        if (is_empty(piece)) continue;
+        if (stm_white_ && !is_white_piece(piece)) continue;
+        if (!stm_white_ && !is_black_piece(piece)) continue;
+        switch (std::tolower(static_cast<unsigned char>(piece))) {
+            case 'p':
+                generate_pawn_moves(sq, moves);
+                break;
+            case 'n':
+                generate_knight_moves(sq, moves);
+                break;
+            case 'b':
+                generate_bishop_moves(sq, moves);
+                break;
+            case 'r':
+                generate_rook_moves(sq, moves);
+                break;
+            case 'q':
+                generate_queen_moves(sq, moves);
+                break;
+            case 'k':
+                generate_king_moves(sq, moves);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+void Board::generate_pawn_moves(int sq, std::vector<Move>& moves) const {
+    bool white = stm_white_;
+    int file = file_of(sq);
+    int rank = rank_of(sq);
+    int forward_dir = white ? 1 : -1;
+    int start_rank = white ? 1 : 6;
+    int promotion_rank = white ? 6 : 1;
+
+    int one_forward_rank = rank + forward_dir;
+    if (on_board(file, one_forward_rank)) {
+        int one_forward_sq = to_index(file, one_forward_rank);
+        if (is_empty(squares_[one_forward_sq])) {
+            if (rank == promotion_rank) {
+                for (int promo = 1; promo <= 4; ++promo) {
+                    moves.push_back(::engine::make_move(sq, one_forward_sq, promo));
+                }
+            } else {
+                moves.push_back(::engine::make_move(sq, one_forward_sq));
+                if (rank == start_rank) {
+                    int two_forward_rank = rank + 2 * forward_dir;
+                    if (on_board(file, two_forward_rank)) {
+                        int two_forward_sq = to_index(file, two_forward_rank);
+                        if (is_empty(squares_[two_forward_sq])) {
+                            moves.push_back(::engine::make_move(sq, two_forward_sq, 0, false, true));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (int df : {-1, 1}) {
+        int target_file = file + df;
+        int target_rank = rank + forward_dir;
+        if (!on_board(target_file, target_rank)) continue;
+        int target_sq = to_index(target_file, target_rank);
+        char target_piece = squares_[target_sq];
+        bool is_capture = !is_empty(target_piece) &&
+                          ((white && is_black_piece(target_piece)) ||
+                           (!white && is_white_piece(target_piece)));
+        if (is_capture) {
+            if (rank == promotion_rank) {
+                for (int promo = 1; promo <= 4; ++promo) {
+                    moves.push_back(::engine::make_move(sq, target_sq, promo, true));
+                }
+            } else {
+                moves.push_back(::engine::make_move(sq, target_sq, 0, true));
+            }
+        }
+        if (en_passant_square_ == target_sq) {
+            moves.push_back(::engine::make_move(sq, target_sq, 0, true, false, true));
+        }
+    }
+}
+
+void Board::generate_knight_moves(int sq, std::vector<Move>& moves) const {
+    bool white = stm_white_;
+    int file = file_of(sq);
+    int rank = rank_of(sq);
+    for (auto [df, dr] : knight_offsets) {
+        int nf = file + df;
+        int nr = rank + dr;
+        if (!on_board(nf, nr)) continue;
+        int target_sq = to_index(nf, nr);
+        char target_piece = squares_[target_sq];
+        if (is_empty(target_piece) || (white && is_black_piece(target_piece)) ||
+            (!white && is_white_piece(target_piece))) {
+            bool capture = !is_empty(target_piece);
+            moves.push_back(::engine::make_move(sq, target_sq, 0, capture));
+        }
+    }
+}
+
+void Board::generate_bishop_moves(int sq, std::vector<Move>& moves) const {
+    bool white = stm_white_;
+    int file = file_of(sq);
+    int rank = rank_of(sq);
+    for (auto [df, dr] : bishop_dirs) {
+        int nf = file + df;
+        int nr = rank + dr;
+        while (on_board(nf, nr)) {
+            int target_sq = to_index(nf, nr);
+            char target_piece = squares_[target_sq];
+            if (is_empty(target_piece)) {
+                moves.push_back(::engine::make_move(sq, target_sq));
+            } else {
+                if ((white && is_black_piece(target_piece)) ||
+                    (!white && is_white_piece(target_piece))) {
+                    moves.push_back(::engine::make_move(sq, target_sq, 0, true));
+                }
+                break;
+            }
+            nf += df;
+            nr += dr;
+        }
+    }
+}
+
+void Board::generate_rook_moves(int sq, std::vector<Move>& moves) const {
+    bool white = stm_white_;
+    int file = file_of(sq);
+    int rank = rank_of(sq);
+    for (auto [df, dr] : rook_dirs) {
+        int nf = file + df;
+        int nr = rank + dr;
+        while (on_board(nf, nr)) {
+            int target_sq = to_index(nf, nr);
+            char target_piece = squares_[target_sq];
+            if (is_empty(target_piece)) {
+                moves.push_back(::engine::make_move(sq, target_sq));
+            } else {
+                if ((white && is_black_piece(target_piece)) ||
+                    (!white && is_white_piece(target_piece))) {
+                    moves.push_back(::engine::make_move(sq, target_sq, 0, true));
+                }
+                break;
+            }
+            nf += df;
+            nr += dr;
+        }
+    }
+}
+
+void Board::generate_queen_moves(int sq, std::vector<Move>& moves) const {
+    generate_bishop_moves(sq, moves);
+    generate_rook_moves(sq, moves);
+}
+
+void Board::generate_king_moves(int sq, std::vector<Move>& moves) const {
+    bool white = stm_white_;
+    int file = file_of(sq);
+    int rank = rank_of(sq);
+    for (auto [df, dr] : king_offsets) {
+        int nf = file + df;
+        int nr = rank + dr;
+        if (!on_board(nf, nr)) continue;
+        int target_sq = to_index(nf, nr);
+        char target_piece = squares_[target_sq];
+        if (is_empty(target_piece) || (white && is_black_piece(target_piece)) ||
+            (!white && is_white_piece(target_piece))) {
+            bool capture = !is_empty(target_piece);
+            moves.push_back(::engine::make_move(sq, target_sq, 0, capture));
+        }
+    }
+
+    // Castling
+    if (white) {
+        int e1 = to_index(4, 0);
+        int f1 = to_index(5, 0);
+        int g1 = to_index(6, 0);
+        int d1 = to_index(3, 0);
+        int c1 = to_index(2, 0);
+        if ((castling_rights_ & CASTLE_WHITE_K) &&
+            is_empty(squares_[f1]) && is_empty(squares_[g1]) &&
+            !in_check(true) && !is_square_attacked(f1, false) &&
+            !is_square_attacked(g1, false)) {
+            moves.push_back(::engine::make_move(e1, g1, 0, false, false, false, true));
+        }
+        if ((castling_rights_ & CASTLE_WHITE_Q) &&
+            is_empty(squares_[d1]) && is_empty(squares_[c1]) &&
+            is_empty(squares_[to_index(1, 0)]) &&
+            !in_check(true) && !is_square_attacked(d1, false) &&
+            !is_square_attacked(c1, false)) {
+            moves.push_back(::engine::make_move(e1, c1, 0, false, false, false, true));
+        }
+    } else {
+        int e8 = to_index(4, 7);
+        int f8 = to_index(5, 7);
+        int g8 = to_index(6, 7);
+        int d8 = to_index(3, 7);
+        int c8 = to_index(2, 7);
+        if ((castling_rights_ & CASTLE_BLACK_K) &&
+            is_empty(squares_[f8]) && is_empty(squares_[g8]) &&
+            !in_check(false) && !is_square_attacked(f8, true) &&
+            !is_square_attacked(g8, true)) {
+            moves.push_back(::engine::make_move(e8, g8, 0, false, false, false, true));
+        }
+        if ((castling_rights_ & CASTLE_BLACK_Q) &&
+            is_empty(squares_[d8]) && is_empty(squares_[c8]) &&
+            is_empty(squares_[to_index(1, 7)]) &&
+            !in_check(false) && !is_square_attacked(d8, true) &&
+            !is_square_attacked(c8, true)) {
+            moves.push_back(::engine::make_move(e8, c8, 0, false, false, false, true));
+        }
+    }
+}
+
+bool Board::in_check(bool white) const {
+    int king_sq = find_king_square(white);
+    if (king_sq == -1) return false;
+    return is_square_attacked(king_sq, !white);
+}
+
+int Board::find_king_square(bool white) const {
+    char king_char = white ? 'K' : 'k';
+    for (int sq = 0; sq < 64; ++sq) {
+        if (squares_[sq] == king_char) return sq;
+    }
+    return -1;
+}
+
+bool Board::is_square_attacked(int sq, bool by_white) const {
+    int file = file_of(sq);
+    int rank = rank_of(sq);
+
+    // Pawns
+    int pawn_dir = by_white ? -1 : 1;
+    for (int df : {-1, 1}) {
+        int nf = file + df;
+        int nr = rank + pawn_dir;
+        if (!on_board(nf, nr)) continue;
+        int target = to_index(nf, nr);
+        char piece = squares_[target];
+        if (by_white) {
+            if (piece == 'P') return true;
+        } else {
+            if (piece == 'p') return true;
+        }
+    }
+
+    // Knights
+    for (auto [df, dr] : knight_offsets) {
+        int nf = file + df;
+        int nr = rank + dr;
+        if (!on_board(nf, nr)) continue;
+        char piece = squares_[to_index(nf, nr)];
+        if (by_white && piece == 'N') return true;
+        if (!by_white && piece == 'n') return true;
+    }
+
+    // Bishops/Queens (diagonals)
+    for (auto [df, dr] : bishop_dirs) {
+        int nf = file + df;
+        int nr = rank + dr;
+        while (on_board(nf, nr)) {
+            char piece = squares_[to_index(nf, nr)];
+            if (!is_empty(piece)) {
+                if (by_white && (piece == 'B' || piece == 'Q')) return true;
+                if (!by_white && (piece == 'b' || piece == 'q')) return true;
+                break;
+            }
+            nf += df;
+            nr += dr;
+        }
+    }
+
+    // Rooks/Queens (straight)
+    for (auto [df, dr] : rook_dirs) {
+        int nf = file + df;
+        int nr = rank + dr;
+        while (on_board(nf, nr)) {
+            char piece = squares_[to_index(nf, nr)];
+            if (!is_empty(piece)) {
+                if (by_white && (piece == 'R' || piece == 'Q')) return true;
+                if (!by_white && (piece == 'r' || piece == 'q')) return true;
+                break;
+            }
+            nf += df;
+            nr += dr;
+        }
+    }
+
+    // King
+    for (auto [df, dr] : king_offsets) {
+        int nf = file + df;
+        int nr = rank + dr;
+        if (!on_board(nf, nr)) continue;
+        char piece = squares_[to_index(nf, nr)];
+        if (by_white && piece == 'K') return true;
+        if (!by_white && piece == 'k') return true;
+    }
+
+    return false;
+}
+
+void Board::do_move(Move move) {
+    int from = move_from(move);
+    int to = move_to(move);
+    char piece = squares_[from];
+    bool white = is_white_piece(piece);
+    squares_[from] = '.';
+
+    if (move_is_enpassant(move)) {
+        int capture_sq = white ? to - 8 : to + 8;
+        squares_[capture_sq] = '.';
+    }
+
+    if (move_is_castling(move)) {
+        if (piece == 'K' && to == to_index(6, 0)) {
+            squares_[to_index(5, 0)] = squares_[to_index(7, 0)];
+            squares_[to_index(7, 0)] = '.';
+        } else if (piece == 'K' && to == to_index(2, 0)) {
+            squares_[to_index(3, 0)] = squares_[to_index(0, 0)];
+            squares_[to_index(0, 0)] = '.';
+        } else if (piece == 'k' && to == to_index(6, 7)) {
+            squares_[to_index(5, 7)] = squares_[to_index(7, 7)];
+            squares_[to_index(7, 7)] = '.';
+        } else if (piece == 'k' && to == to_index(2, 7)) {
+            squares_[to_index(3, 7)] = squares_[to_index(0, 7)];
+            squares_[to_index(0, 7)] = '.';
+        }
+    }
+
+    int promo = move_promo(move);
+    if (promo) {
+        piece = promotion_from_code(promo, white);
+    }
+
+    squares_[to] = piece;
+
+    // Update castling rights
+    if (piece == 'K') {
+        castling_rights_ &= ~(CASTLE_WHITE_K | CASTLE_WHITE_Q);
+    } else if (piece == 'k') {
+        castling_rights_ &= ~(CASTLE_BLACK_K | CASTLE_BLACK_Q);
+    }
+
+    if (from == to_index(0, 0) || to == to_index(0, 0)) {
+        castling_rights_ &= ~CASTLE_WHITE_Q;
+    }
+    if (from == to_index(7, 0) || to == to_index(7, 0)) {
+        castling_rights_ &= ~CASTLE_WHITE_K;
+    }
+    if (from == to_index(0, 7) || to == to_index(0, 7)) {
+        castling_rights_ &= ~CASTLE_BLACK_Q;
+    }
+    if (from == to_index(7, 7) || to == to_index(7, 7)) {
+        castling_rights_ &= ~CASTLE_BLACK_K;
+    }
+
+    en_passant_square_ = -1;
+    if (std::tolower(static_cast<unsigned char>(piece)) == 'p' && move_is_double_pawn(move)) {
+        en_passant_square_ = white ? to - 8 : to + 8;
+    }
+
+    stm_white_ = !stm_white_;
+}
+
+} // namespace engine

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -3,9 +3,11 @@
 
 namespace engine {
 
-Move Search::find_bestmove(Board& /*b*/, const Limits& /*lim*/) {
-    // TODO: after movegen exists, pick a legal move (PV move or first legal).
-    return MOVE_NONE;
+Move Search::find_bestmove(Board& b, const Limits& /*lim*/) {
+    auto legal = b.generate_legal_moves();
+    if (legal.empty()) return MOVE_NONE;
+    // Placeholder: return the first legal move.
+    return legal.front();
 }
 
 } // namespace engine

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -139,11 +139,16 @@ void Uci::cmd_go(const std::string& s) {
     Limits lim = parse_go_tokens(t);
     (void)lim;
 
-    // Minimal output for GUI friendliness
-    std::cout << "info depth 1 score cp 0 nodes 1 time 0 pv" << "\n" << std::flush;
+    auto best = g_search.find_bestmove(g_board, lim);
+    std::string best_uci = g_board.move_to_uci(best);
 
-    // Until movegen/search exists, we cannot choose a legal move.
-    std::cout << "bestmove (none)\n" << std::flush;
+    std::cout << "info depth 1 score cp 0 nodes 1 time 0 pv" << "\n";
+    if (best == MOVE_NONE) {
+        std::cout << "bestmove (none)\n";
+    } else {
+        std::cout << "bestmove " << best_uci << "\n";
+    }
+    std::cout << std::flush;
 }
 
 void Uci::cmd_stop() { g_stop = true; }

--- a/tests/legal_moves_cli.cpp
+++ b/tests/legal_moves_cli.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <string>
+#include "engine/core/board.hpp"
+
+int main() {
+    std::string fen;
+    if (!std::getline(std::cin, fen)) {
+        return 1;
+    }
+    engine::Board board;
+    if (!board.set_fen(fen)) {
+        std::cerr << "invalid fen";
+        return 2;
+    }
+    auto moves = board.generate_legal_moves();
+    for (size_t i = 0; i < moves.size(); ++i) {
+        if (i) std::cout << ' ';
+        std::cout << board.move_to_uci(moves[i]);
+    }
+    std::cout << '\n';
+    return 0;
+}

--- a/tests/movegen_tests.cpp
+++ b/tests/movegen_tests.cpp
@@ -1,0 +1,58 @@
+#include "engine/core/board.hpp"
+#include "engine/search/search.hpp"
+#include <cassert>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace {
+std::unordered_set<std::string> moves_to_set(engine::Board& board,
+                                             const std::vector<engine::Move>& moves) {
+    std::unordered_set<std::string> out;
+    out.reserve(moves.size());
+    for (engine::Move move : moves) {
+        out.insert(board.move_to_uci(move));
+    }
+    return out;
+}
+} // namespace
+
+int main() {
+    using namespace engine;
+
+    Board board;
+    board.set_startpos();
+    auto start_moves = board.generate_legal_moves();
+    auto start_set = moves_to_set(board, start_moves);
+    assert(start_moves.size() == 20);
+    assert(start_set.contains("e2e4"));
+    assert(start_set.contains("g1f3"));
+    assert(!board.make_move_uci("e2e5"));
+
+    board.set_fen("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    auto castle_moves = board.generate_legal_moves();
+    auto castle_set = moves_to_set(board, castle_moves);
+    assert(castle_set.contains("e1g1"));
+    assert(castle_set.contains("e1c1"));
+
+    board.set_fen("r3k2r/8/8/8/8/8/5r2/R3K2R w KQ - 0 1");
+    auto blocked_moves = board.generate_legal_moves();
+    auto blocked_set = moves_to_set(board, blocked_moves);
+    assert(!blocked_set.contains("e1g1"));
+
+    board.set_fen("7k/8/8/3pP3/8/8/8/7K w - d6 0 1");
+    auto ep_moves = board.generate_legal_moves();
+    auto ep_set = moves_to_set(board, ep_moves);
+    assert(ep_set.contains("e5d6"));
+    assert(board.make_move_uci("e5d6"));
+    assert(!board.white_to_move());
+
+    board.set_fen("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1");
+    auto no_moves = board.generate_legal_moves();
+    assert(no_moves.empty());
+    Search search;
+    auto best = search.find_bestmove(board, Limits{});
+    assert(best == MOVE_NONE);
+
+    return 0;
+}

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import textwrap
+
+
+def run_engine(engine_path, commands):
+    proc = subprocess.Popen(
+        [engine_path],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    script = "\n".join(commands) + "\n"
+    out, err = proc.communicate(script, timeout=5)
+    if proc.returncode not in (0, None):
+        raise RuntimeError(f"Engine exited with {proc.returncode}: {err}")
+    bestmove = None
+    for line in out.splitlines():
+        if line.startswith("bestmove"):
+            parts = line.split()
+            if len(parts) >= 2:
+                bestmove = parts[1]
+            break
+    if bestmove is None:
+        raise AssertionError(f"Engine did not report bestmove. Output:\n{out}")
+    return bestmove, out
+
+
+def legal_moves(helper_path, fen):
+    result = subprocess.run(
+        [helper_path],
+        input=fen,
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=5,
+    )
+    moves = result.stdout.strip().split()
+    return moves
+
+
+def assert_bestmove_is_legal(engine_path, helper_path, fen, position_cmd):
+    commands = [
+        "uci",
+        "isready",
+        "ucinewgame",
+        position_cmd,
+        "go depth 1",
+        "quit",
+    ]
+    bestmove, output = run_engine(engine_path, commands)
+    if bestmove == "(none)":
+        raise AssertionError(f"Engine reported no move for position: {position_cmd}\n{output}")
+    moves = legal_moves(helper_path, fen)
+    assert bestmove in moves, textwrap.dedent(
+        f"""
+        Engine returned illegal move {bestmove}.
+        Position command: {position_cmd}
+        Legal moves: {moves}
+        Engine output:\n{output}
+        """
+    )
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: test_go.py <engine> <helper>")
+        return 2
+    engine_path, helper_path = sys.argv[1:3]
+    tests = [
+        (
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            "position startpos",
+        ),
+        (
+            "7k/8/8/8/8/8/6r1/7K w - - 0 1",
+            "position fen 7k/8/8/8/8/8/6r1/7K w - - 0 1",
+        ),
+    ]
+    for fen, cmd in tests:
+        assert_bestmove_is_legal(engine_path, helper_path, fen, cmd)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import subprocess
+import subprocess  # Needed to spawn the engine and helper processes
 import sys
 import textwrap
 


### PR DESCRIPTION
## Summary
- implement move encoding helpers and board-side legal move generation, including basic make/uci helpers
- hook the new move generation into search and the UCI go command so a legal move is reported
- add a legal move listing helper, Python-based go command test, and update the build to expose a reusable core library

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d76e082ef483279004c1809f67a335