### PR TITLE
Clean up board parsing and build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,6 @@ if (ENABLE_LTO)
   endif()
 endif()
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-
 file(GLOB_RECURSE SRC_FILES
   src/*.cpp
 )
@@ -44,9 +42,10 @@ set(MAIN_SOURCE ${CMAKE_SOURCE_DIR}/src/main.cpp)
 list(REMOVE_ITEM SRC_FILES ${MAIN_SOURCE})
 
 add_library(sirio_core ${SRC_FILES})
+target_include_directories(sirio_core PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_compile_definitions(sirio_core PUBLIC
-  ENGINE_NAME=\"SirioC\"
-  ENGINE_VERSION=\"0.1.0\"
+  ENGINE_NAME="SirioC"
+  ENGINE_VERSION="0.1.0"
 )
 
 add_executable(SirioC ${MAIN_SOURCE})
@@ -64,25 +63,15 @@ if (MINGW)
   target_link_libraries(movegen_tests PRIVATE stdc++ stdc++fs)
 endif()
 
- codex/implement-legal-move-generation-and-testing
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
-enable_testing()
+
+add_executable(SirioCTests tests/board_fen_tests.cpp)
+target_link_libraries(SirioCTests PRIVATE sirio_core)
+
 add_test(NAME movegen_unit_tests COMMAND movegen_tests)
 add_test(NAME go_command_responds_with_legal_move
          COMMAND Python3::Interpreter
                  ${CMAKE_SOURCE_DIR}/tests/test_go.py
                  $<TARGET_FILE:SirioC>
-                 $<TARGET_FILE
-target_compile_definitions(SirioC PRIVATE
-  ENGINE_NAME=\"SirioC\"
-  ENGINE_VERSION=\"0.1.0\"
-)
-
-add_executable(SirioCTests
-  tests/board_fen_tests.cpp
-  src/core/board.cpp
-  src/core/fen.cpp
-)
-
+                 $<TARGET_FILE:legal_moves_cli>)
 add_test(NAME board_fen_tests COMMAND SirioCTests)
-main

--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -59,7 +59,7 @@ public:
     const std::string& last_fen() const { return last_fen_; }
     const std::array<uint64_t, PIECE_NB>& piece_bitboards() const { return piece_bitboards_; }
     const std::array<uint64_t, OCC_NB>& occupancy() const { return occupancy_; }
-    char piece_on(int square) const { return board_[square]; }
+    char piece_on(int square) const { return squares_[square]; }
     uint8_t castling_rights() const { return castling_rights_; }
     int en_passant_square() const { return en_passant_square_; }
     int halfmove_clock() const { return halfmove_clock_; }
@@ -96,15 +96,12 @@ private:
     bool stm_white_ = true;
     std::array<uint64_t, PIECE_NB> piece_bitboards_{};
     std::array<uint64_t, OCC_NB> occupancy_{};
-    std::array<char, 64> board_{};
     uint8_t castling_rights_ = 0;
     int en_passant_square_ = INVALID_SQUARE;
     int halfmove_clock_ = 0;
     int fullmove_number_ = 1;
     std::string last_fen_;
     std::array<char, 64> squares_{};
-    uint8_t castling_rights_ = 0;
-    int en_passant_square_ = -1;
 };
 
 } // namespace engine

--- a/src/core/board.cpp
+++ b/src/core/board.cpp
@@ -1,14 +1,13 @@
 #include "engine/core/board.hpp"
 #include "engine/core/fen.hpp"
+
 #include <algorithm>
 #include <array>
 #include <cctype>
-
-#include <array>
-#include <cctype>
 #include <charconv>
-main
 #include <sstream>
+#include <string>
+#include <system_error>
 #include <vector>
 
 namespace engine {
@@ -140,79 +139,16 @@ bool parse_en_passant_field(const std::string& field, int& square) {
 
 Board::Board() { set_startpos(); }
 
-void Board::set_startpos() {
- codex/implement-legal-move-generation-and-testing
-    set_fen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    (void)set_fen(std::string(kStartposFEN));
- main
-}
+void Board::set_startpos() { set_fen(std::string(kStartposFEN)); }
 
 bool Board::set_fen(const std::string& fen) {
     if (!fen::is_valid_fen(fen)) return false;
+
     std::istringstream iss(fen);
-codex/implement-legal-move-generation-and-testing
-    std::vector<std::string> tokens;
-    std::string tok;
-    while (iss >> tok) tokens.push_back(tok);
-    if (tokens.size() < 4) return false;
-
-    std::array<char, 64> new_squares;
-    std::fill(new_squares.begin(), new_squares.end(), '.');
-    bool new_stm_white = tokens[1] == "w";
-    uint8_t new_castling = 0;
-    int new_en_passant = -1;
-
-    int rank = 7;
-    int file = 0;
-    for (char c : tokens[0]) {
-        if (c == '/') {
-            if (file != 8) return false;
-            --rank;
-            if (rank < 0) return false;
-            file = 0;
-            continue;
-        }
-        if (std::isdigit(static_cast<unsigned char>(c))) {
-            file += c - '0';
-        } else {
-            if (file >= 8 || rank < 0) return false;
-            new_squares[rank * 8 + file] = c;
-            ++file;
-        }
-    }
-    if (rank != 0 || file != 8) {
-        return false;
-    }
-
-    if (tokens[2] != "-") {
-        for (char c : tokens[2]) {
-            switch (c) {
-                case 'K': new_castling |= CASTLE_WHITE_K; break;
-                case 'Q': new_castling |= CASTLE_WHITE_Q; break;
-                case 'k': new_castling |= CASTLE_BLACK_K; break;
-                case 'q': new_castling |= CASTLE_BLACK_Q; break;
-                default: break;
-            }
-        }
-    }
-
-    if (tokens[3] != "-") {
-        if (tokens[3].size() == 2) {
-            char file_char = tokens[3][0];
-            char rank_char = tokens[3][1];
-            if (file_char >= 'a' && file_char <= 'h' && rank_char >= '1' && rank_char <= '8') {
-                new_en_passant = (rank_char - '1') * 8 + (file_char - 'a');
-            }
-        }
-    }
-
-    squares_ = new_squares;
-    stm_white_ = new_stm_white;
-    castling_rights_ = new_castling;
-    en_passant_square_ = new_en_passant;
-
-    std::string board_field, stm_field, castling_field, ep_field, halfmove_field, fullmove_field;
-    if (!(iss >> board_field >> stm_field >> castling_field >> ep_field >> halfmove_field >> fullmove_field)) {
+    std::string board_field, stm_field, castling_field, ep_field, halfmove_field,
+        fullmove_field;
+    if (!(iss >> board_field >> stm_field >> castling_field >> ep_field >> halfmove_field >>
+          fullmove_field)) {
         return false;
     }
     std::string extra;
@@ -240,13 +176,12 @@ codex/implement-legal-move-generation-and-testing
 
     piece_bitboards_ = piece_bb;
     occupancy_ = occupancy;
-    board_ = board_array;
+    squares_ = board_array;
     castling_rights_ = castling;
     en_passant_square_ = ep_square;
     halfmove_clock_ = halfmove;
     fullmove_number_ = fullmove;
     stm_white_ = stm_white;
-    main
     last_fen_ = fen;
     return true;
 }
@@ -258,11 +193,11 @@ bool Board::apply_moves_uci(const std::vector<std::string>& uci_moves) {
     return true;
 }
 
-bool Board::make_move(Move move) {
+bool Board::make_move(Move m) {
     auto legal = generate_legal_moves();
-    for (Move m : legal) {
-        if (m == move) {
-            do_move(m);
+    for (Move move : legal) {
+        if (move == m) {
+            do_move(move);
             return true;
         }
     }
@@ -271,9 +206,9 @@ bool Board::make_move(Move move) {
 
 bool Board::make_move_uci(const std::string& uci) {
     auto legal = generate_legal_moves();
-    for (Move m : legal) {
-        if (move_to_uci(m) == uci) {
-            do_move(m);
+    for (Move move : legal) {
+        if (move_to_uci(move) == uci) {
+            do_move(move);
             return true;
         }
     }
@@ -296,29 +231,17 @@ std::string Board::move_to_uci(Move move) const {
     return out;
 }
 
-bool Board::is_white_piece(char piece) {
-    return piece >= 'A' && piece <= 'Z';
-}
+bool Board::is_white_piece(char piece) { return piece >= 'A' && piece <= 'Z'; }
 
-bool Board::is_black_piece(char piece) {
-    return piece >= 'a' && piece <= 'z';
-}
+bool Board::is_black_piece(char piece) { return piece >= 'a' && piece <= 'z'; }
 
-bool Board::is_empty(char piece) {
-    return piece == '.';
-}
+bool Board::is_empty(char piece) { return piece == '.'; }
 
-int Board::file_of(int sq) {
-    return sq % 8;
-}
+int Board::file_of(int sq) { return sq % 8; }
 
-int Board::rank_of(int sq) {
-    return sq / 8;
-}
+int Board::rank_of(int sq) { return sq / 8; }
 
-int Board::to_index(int file, int rank) {
-    return rank * 8 + file;
-}
+int Board::to_index(int file, int rank) { return rank * 8 + file; }
 
 std::string Board::square_to_string(int sq) const {
     std::string s;
@@ -329,11 +252,11 @@ std::string Board::square_to_string(int sq) const {
 
 char Board::promotion_from_code(int code, bool white) const {
     switch (code) {
-        case 1: return white ? 'N' : 'n';
-        case 2: return white ? 'B' : 'b';
-        case 3: return white ? 'R' : 'r';
-        case 4: return white ? 'Q' : 'q';
-        default: return white ? 'P' : 'p';
+    case 1: return white ? 'N' : 'n';
+    case 2: return white ? 'B' : 'b';
+    case 3: return white ? 'R' : 'r';
+    case 4: return white ? 'Q' : 'q';
+    default: return white ? 'P' : 'p';
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the corrupted board parsing implementation with a clean, validated version that keeps the board state consistent
- remove duplicate state from the Board class so runtime access uses the actively updated square array
- rewrite the CMake configuration to remove stray artifacts and properly wire the shared core library and tests

## Testing
- cmake -S . -B build
- cmake --build build
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68d7797454d48327958ecbeeef5febb2