### PR TITLE
Fix tablebase hash initialization for C++20

### DIFF
--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -730,7 +730,7 @@ static void add_to_hash(struct BaseEntry *ptr, uint64_t key)
 
   tbHash[idx].key = key;
   tbHash[idx].ptr = ptr;
-  atomic_init(&tbHash[idx].error, false);
+  atomic_store_explicit(&tbHash[idx].error, false, memory_order_relaxed);
 }
 
 #define pchr(i) piece_to_char[QUEEN - (i)]


### PR DESCRIPTION
## Summary
- replace the deprecated `atomic_init` usage in the tablebase hash setup with `atomic_store_explicit`

## Testing
- cmake -S . -B build && cmake --build build -j

------
https://chatgpt.com/codex/tasks/task_e_68d79cf5a4808327ba110e1d8970701e