### PR TITLE
Enhance search heuristics and add null move support

### DIFF
--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -66,6 +66,7 @@ public:
         bool prev_stm_white = true;
         bool was_castling = false;
         bool was_enpassant = false;
+        bool was_null_move = false;
         int prev_mg = 0;
         int prev_eg = 0;
         int prev_phase = 0;
@@ -74,6 +75,7 @@ public:
     bool make_move(Move m);
     bool make_move_uci(const std::string& uci);
     void apply_move(Move move, State& state);
+    void apply_null_move(State& state);
     void undo_move(const State& state);
     void undo_move();
     std::vector<Move> generate_legal_moves();

--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -65,14 +65,15 @@ private:
 
     Result search_position(Board& board, const Limits& lim);
     int negamax(Board& board, int depth, int alpha, int beta, bool pv_node, int ply,
-                ThreadData& thread_data);
+                ThreadData& thread_data, Move prev_move);
     int quiescence(Board& board, int alpha, int beta, int ply, ThreadData& thread_data);
     void store_tt(uint64_t key, Move best, int depth, int score, int flag, int ply,
                   int eval);
     bool probe_tt(const Board& board, int depth, int alpha, int beta, Move& tt_move,
                   int& score, int ply) const;
     std::vector<Move> order_moves(const Board& board, std::vector<Move>& moves,
-                                  Move tt_move, int ply, const ThreadData& thread_data) const;
+                                  Move tt_move, int ply, const ThreadData& thread_data,
+                                  Move prev_move) const;
     void update_killers(ThreadData& thread_data, int ply, Move move);
     void update_history(ThreadData& thread_data, Move move, int delta);
     std::vector<Move> extract_pv(const Board& board, Move best) const;


### PR DESCRIPTION
## Summary
- add dedicated null-move application/undo support to the board state so pruning can skip full move generation
- integrate aspiration windows, null-move pruning, razoring, reverse futility, and late-move/history-based pruning into the negamax search
- improve move ordering with counter-move heuristics and SEE-based capture filtering for more efficient node expansion

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d7a73523608327a2d7a4e4ed509990