### PR TITLE
Enhance search pruning and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,20 +120,12 @@ SirioC blends ideas from Berserk and Stockfish in the following ways:
 
 ### Search improvement tasks
 
-To keep pace with other competitive UCI engines, the search stack can be
-expanded with the following upgrades:
+To keep pace with other competitive UCI engines, future work should continue to
+refine the selectivity that now powers SirioC's search:
 
-* Add move-count based pruning (including improvements such as improved late
-  move pruning and move-overhead aware reductions) to trim obviously futile
-  branches earlier.
-* Introduce a singular-extension search to better recognise forcing
-  continuations in tactical positions.
-* Implement probabilistic cut (ProbCut) and enhanced beta pruning tuned for the
-  existing evaluation scale to shave additional nodes without missing tactics.
-* Add a robust internal iterative deepening framework for quiet nodes so that
-  principal variation moves remain strong even when TT entries are shallow.
-* Improve the multi-threaded search balance with adaptive aspiration windows
-  and smarter fail-high/fail-low recovery heuristics.
+* Instrument automated tuning for the new pruning margins and reduction tables
+  so the enhanced move-count pruning, singular extensions, and beta/ProbCut
+  thresholds stay balanced across hardware and time controls.
 
 ## Bench command
 

--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -65,12 +65,12 @@ private:
 
     Result search_position(Board& board, const Limits& lim);
     int negamax(Board& board, int depth, int alpha, int beta, bool pv_node, int ply,
-                ThreadData& thread_data, Move prev_move);
+                ThreadData& thread_data, Move prev_move, bool in_iid = false);
     int quiescence(Board& board, int alpha, int beta, int ply, ThreadData& thread_data);
     void store_tt(uint64_t key, Move best, int depth, int score, int flag, int ply,
                   int eval);
     bool probe_tt(const Board& board, int depth, int alpha, int beta, Move& tt_move,
-                  int& score, int ply) const;
+                  int& score, int ply, int& tt_depth, int& tt_flag, int& tt_eval) const;
     std::vector<Move> order_moves(const Board& board, std::vector<Move>& moves,
                                   Move tt_move, int ply, const ThreadData& thread_data,
                                   Move prev_move) const;


### PR DESCRIPTION
## Summary
- add move-count aware pruning, ProbCut, singular extensions, and IID refinements to negamax
- tune aspiration windows and TT probing to stabilize multi-threaded root search
- refresh README search roadmap to focus on tuning the new pruning framework

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build -j
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d7b3563cbc83279a0c60abdcf520a4