### PR TITLE
Ensure NNUE network reloads with UCI options

### DIFF
--- a/include/engine/eval/nnue/evaluator.hpp
+++ b/include/engine/eval/nnue/evaluator.hpp
@@ -13,10 +13,12 @@ public:
     bool load_network(const std::string& path);
     int eval_cp(const engine::Board& board) const;
     bool loaded() const noexcept { return loaded_; }
+    const std::string& loaded_path() const noexcept { return loaded_path_; }
 
 private:
     bool loaded_ = false;
     std::vector<std::uint8_t> raw_network_;
+    std::string loaded_path_{};
 };
 
 } // namespace engine::nnue

--- a/src/eval/nnue/evaluator.cpp
+++ b/src/eval/nnue/evaluator.cpp
@@ -12,10 +12,12 @@ bool Evaluator::load_network(const std::string& path) {
     if (!file) {
         loaded_ = false;
         raw_network_.clear();
+        loaded_path_.clear();
         return false;
     }
     raw_network_.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
     loaded_ = !raw_network_.empty();
+    loaded_path_ = loaded_ ? path : std::string{};
     return loaded_;
 }
 

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -44,7 +44,19 @@ static bool g_stop = false;
 static bool g_use_syzygy = false;
 static std::string g_syzygy_path;
 
+static void ensure_nnue_loaded() {
+    if (!g_use_nnue) return;
+    if (!g_eval.loaded() || g_eval.loaded_path() != g_eval_file) {
+        if (!g_eval.load_network(g_eval_file)) {
+            std::cout << "info string Failed to load NNUE network '" << g_eval_file
+                      << "', disabling UseNNUE\n" << std::flush;
+            g_use_nnue = false;
+        }
+    }
+}
+
 static void sync_search_options() {
+    ensure_nnue_loaded();
     g_search.set_hash(g_hash_mb);
     g_search.set_threads(g_threads);
     g_search.set_numa_offset(g_numa_offset);
@@ -106,8 +118,7 @@ void Uci::cmd_isready() {
 void Uci::cmd_ucinewgame() {
     g_stop = false;
     g_board.set_startpos();
-    // (Re)load network optionally
-    if (g_use_nnue) g_eval.load_network(g_eval_file);
+    ensure_nnue_loaded();
     sync_search_options();
 }
 


### PR DESCRIPTION
## Summary
- track the currently loaded NNUE network path so it can be re-used or refreshed when options change
- automatically load or reload the configured NNUE file whenever search options are synchronized and disable UseNNUE on failure
- surface load failures as UCI info strings so frontends can react accordingly

## Testing
- cmake -S . -B build
- cmake --build build
- cd build && ctest


------
https://chatgpt.com/codex/tasks/task_e_68d91bdf1f0483279f5fbc6a35d5a206