### PR TITLE
Bundle placeholder NNUE networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build/
 *.nnue
+!nn-1c0000000000.nnue
+!nn-37f18f62d772.nnue
 *.exe
 *.pdb
 *.obj

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ NNUE training material. Material and positional terms are blended between
 middlegame and endgame phases, and a small tempo bonus favors the side to move.
 The NNUE accumulator infrastructure is wired through the board state, enabling
 fast inference once the NNUE evaluator is connected. Until incremental NNUE
-updates land, the classical evaluation remains the default.
+updates land, the classical evaluation remains the default. Placeholder
+`.nnue` network files are bundled so the UCI options resolve to real files even
+though full neural evaluation is not yet implemented.
 
 ### Engine influences
 

--- a/include/engine/eval/nnue/evaluator.hpp
+++ b/include/engine/eval/nnue/evaluator.hpp
@@ -13,10 +13,12 @@ public:
     bool load_network(const std::string& path);
     int eval_cp(const engine::Board& board) const;
     bool loaded() const noexcept { return loaded_; }
+    const std::string& loaded_path() const noexcept { return loaded_path_; }
 
 private:
     bool loaded_ = false;
     std::vector<std::uint8_t> raw_network_;
+    std::string loaded_path_{};
 };
 
 } // namespace engine::nnue

--- a/nn-1c0000000000.nnue
+++ b/nn-1c0000000000.nnue
@@ -1,0 +1,1 @@
+SirioC NNUE placeholder v1

--- a/nn-37f18f62d772.nnue
+++ b/nn-37f18f62d772.nnue
@@ -1,0 +1,1 @@
+SirioC small NNUE placeholder v1

--- a/src/eval/nnue/evaluator.cpp
+++ b/src/eval/nnue/evaluator.cpp
@@ -12,10 +12,12 @@ bool Evaluator::load_network(const std::string& path) {
     if (!file) {
         loaded_ = false;
         raw_network_.clear();
+        loaded_path_.clear();
         return false;
     }
     raw_network_.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
     loaded_ = !raw_network_.empty();
+    loaded_path_ = loaded_ ? path : std::string{};
     return loaded_;
 }
 

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -44,7 +44,19 @@ static bool g_stop = false;
 static bool g_use_syzygy = false;
 static std::string g_syzygy_path;
 
+static void ensure_nnue_loaded() {
+    if (!g_use_nnue) return;
+    if (!g_eval.loaded() || g_eval.loaded_path() != g_eval_file) {
+        if (!g_eval.load_network(g_eval_file)) {
+            std::cout << "info string Failed to load NNUE network '" << g_eval_file
+                      << "', disabling UseNNUE\n" << std::flush;
+            g_use_nnue = false;
+        }
+    }
+}
+
 static void sync_search_options() {
+    ensure_nnue_loaded();
     g_search.set_hash(g_hash_mb);
     g_search.set_threads(g_threads);
     g_search.set_numa_offset(g_numa_offset);
@@ -106,8 +118,7 @@ void Uci::cmd_isready() {
 void Uci::cmd_ucinewgame() {
     g_stop = false;
     g_board.set_startpos();
-    // (Re)load network optionally
-    if (g_use_nnue) g_eval.load_network(g_eval_file);
+    ensure_nnue_loaded();
     sync_search_options();
 }
 


### PR DESCRIPTION
## Summary
- commit placeholder NNUE network files so the default EvalFile paths resolve during UCI startup
- adjust the ignore rules to keep the bundled placeholder networks under version control
- document in the README that the tracked networks are placeholders until full NNUE inference is implemented

## Testing
- cmake -S . -B build
- cmake --build build
- cd build && ctest
- printf 'uci\ngo depth 1\n' | ./build/SirioC


------
https://chatgpt.com/codex/tasks/task_e_68d91bdf1f0483279f5fbc6a35d5a206