### PR TITLE
Enable loading of simple NNUE network files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ NNUE training material. Material and positional terms are blended between
 middlegame and endgame phases, and a small tempo bonus favors the side to move.
 The NNUE accumulator infrastructure is wired through the board state, enabling
 fast inference once the NNUE evaluator is connected. Until incremental NNUE
-updates land, the classical evaluation remains the default. Placeholder
-`.nnue` network files are bundled so the UCI options resolve to real files even
-though full neural evaluation is not yet implemented.
+updates land, the classical evaluation remains the default, but lightweight
+text-based `.nnue` networks now ship with the engine so the UCI `UseNNUE`
+option immediately loads a simple neural blend on start-up.
 
 ### Engine influences
 

--- a/include/engine/eval/nnue/evaluator.hpp
+++ b/include/engine/eval/nnue/evaluator.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
-#include <vector>
 
 namespace engine { class Board; }
 
@@ -16,8 +16,17 @@ public:
     const std::string& loaded_path() const noexcept { return loaded_path_; }
 
 private:
+    struct Network {
+        static constexpr std::size_t kFeatureCount = 7;
+        double bias = 0.0;
+        std::array<double, kFeatureCount> weights{};
+    };
+
+    std::array<double, Network::kFeatureCount>
+    compute_features(const engine::Board& board) const;
+
     bool loaded_ = false;
-    std::vector<std::uint8_t> raw_network_;
+    Network network_{};
     std::string loaded_path_{};
 };
 

--- a/nn-1c0000000000.nnue
+++ b/nn-1c0000000000.nnue
@@ -1,1 +1,3 @@
-SirioC NNUE placeholder v1
+SirioC SimpleNNUE v1
+bias 0.0
+weights 1.0 5.0 3.5 3.5 2.0 1.5 20.0

--- a/nn-37f18f62d772.nnue
+++ b/nn-37f18f62d772.nnue
@@ -1,1 +1,3 @@
-SirioC small NNUE placeholder v1
+SirioC SimpleNNUE v1
+bias 0.0
+weights 0.9 4.5 3.0 3.0 1.8 1.2 15.0

--- a/src/eval/nnue/evaluator.cpp
+++ b/src/eval/nnue/evaluator.cpp
@@ -1,5 +1,8 @@
 #include "engine/eval/nnue/evaluator.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <fstream>
 
 #include "engine/core/board.hpp"
@@ -8,21 +11,111 @@
 namespace engine::nnue {
 
 bool Evaluator::load_network(const std::string& path) {
-    std::ifstream file(path, std::ios::binary);
+    std::ifstream file(path);
     if (!file) {
         loaded_ = false;
-        raw_network_.clear();
         loaded_path_.clear();
         return false;
     }
-    raw_network_.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
-    loaded_ = !raw_network_.empty();
-    loaded_path_ = loaded_ ? path : std::string{};
-    return loaded_;
+    std::string header;
+    if (!std::getline(file, header)) {
+        loaded_ = false;
+        loaded_path_.clear();
+        return false;
+    }
+    if (!header.empty() && header.back() == '\r') header.pop_back();
+    if (header != "SirioC SimpleNNUE v1") {
+        loaded_ = false;
+        loaded_path_.clear();
+        return false;
+    }
+
+    std::string bias_label;
+    double bias_value = 0.0;
+    if (!(file >> bias_label >> bias_value) || bias_label != "bias") {
+        loaded_ = false;
+        loaded_path_.clear();
+        return false;
+    }
+
+    std::string weights_label;
+    if (!(file >> weights_label) || weights_label != "weights") {
+        loaded_ = false;
+        loaded_path_.clear();
+        return false;
+    }
+
+    Network network{};
+    network.bias = bias_value;
+    for (double& weight : network.weights) {
+        if (!(file >> weight)) {
+            loaded_ = false;
+            loaded_path_.clear();
+            return false;
+        }
+    }
+
+    loaded_ = true;
+    network_ = network;
+    loaded_path_ = path;
+    return true;
 }
 
 int Evaluator::eval_cp(const engine::Board& board) const {
-    return board.nnue_accumulator().evaluate(board.white_to_move());
+    if (!loaded_) {
+        return board.nnue_accumulator().evaluate(board.white_to_move());
+    }
+
+    auto features = compute_features(board);
+    double score = network_.bias;
+    for (std::size_t i = 0; i < Network::kFeatureCount; ++i) {
+        score += network_.weights[i] * features[i];
+    }
+    score = std::clamp(score, -30000.0, 30000.0);
+    int rounded = static_cast<int>(std::round(score));
+    return board.white_to_move() ? rounded : -rounded;
+}
+
+std::array<double, Evaluator::Network::kFeatureCount>
+Evaluator::compute_features(const engine::Board& board) const {
+    std::array<double, Network::kFeatureCount> features{};
+
+    features[0] = static_cast<double>(board.nnue_accumulator().evaluate(true));
+
+    std::array<int, 6> white_counts{};
+    std::array<int, 6> black_counts{};
+
+    const auto& squares = board.squares();
+    for (char piece : squares) {
+        switch (piece) {
+        case 'P': white_counts[0]++; break;
+        case 'N': white_counts[1]++; break;
+        case 'B': white_counts[2]++; break;
+        case 'R': white_counts[3]++; break;
+        case 'Q': white_counts[4]++; break;
+        case 'K': white_counts[5]++; break;
+        case 'p': black_counts[0]++; break;
+        case 'n': black_counts[1]++; break;
+        case 'b': black_counts[2]++; break;
+        case 'r': black_counts[3]++; break;
+        case 'q': black_counts[4]++; break;
+        case 'k': black_counts[5]++; break;
+        default: break;
+        }
+    }
+
+    auto diff = [&](int idx) {
+        return static_cast<double>(white_counts[idx] - black_counts[idx]);
+    };
+
+    features[1] = diff(0);
+    features[2] = diff(1);
+    features[3] = diff(2);
+    features[4] = diff(3);
+    features[5] = diff(4);
+    features[6] = static_cast<double>((white_counts[2] >= 2 ? 1 : 0) - (black_counts[2] >= 2 ? 1 : 0));
+
+    return features;
 }
 
 } // namespace engine::nnue

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -51,6 +51,9 @@ static void ensure_nnue_loaded() {
             std::cout << "info string Failed to load NNUE network '" << g_eval_file
                       << "', disabling UseNNUE\n" << std::flush;
             g_use_nnue = false;
+        } else {
+            std::cout << "info string Loaded NNUE network '" << g_eval_file << "'\n"
+                      << std::flush;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the NNUE evaluator scaffolding with a feature-based scorer that consumes lightweight network files
- add simple text NNUE definitions and report successful loads through the UCI interface
- document the bundled networks so the README reflects the new behavior

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d9582974c4832796b5b9fc052f794c