### PR TITLE
Integrate Syzygy tablebase config and probing

### DIFF
--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "engine/syzygy/syzygy.hpp"
 #include "engine/types.hpp"
 #include <array>
 #include <atomic>
@@ -42,8 +43,7 @@ public:
     void set_threads(int threads);
     void set_hash(int megabytes);
     void stop();
-    void set_use_syzygy(bool enable);
-    void set_syzygy_path(std::string path);
+    void set_syzygy_config(syzygy::TBConfig config);
     void set_numa_offset(int offset);
     void set_ponder(bool enable);
     void set_multi_pv(int multi_pv);
@@ -134,7 +134,8 @@ private:
     void update_history(ThreadData& thread_data, Move move, int delta);
     std::vector<Move> extract_pv(const Board& board, Move best) const;
     int evaluate(const Board& board) const;
-    std::optional<int> probe_syzygy(const Board& board) const;
+    std::optional<int> probe_syzygy(const Board& board, int depth,
+                                    bool root_probe) const;
 
     std::vector<TTEntry> tt_;
     size_t tt_mask_ = 0;
@@ -146,8 +147,7 @@ private:
     size_t thread_data_thread_count_ = 0;
     bool thread_data_initialized_ = false;
     int threads_ = 1;
-    bool use_syzygy_ = false;
-    std::string syzygy_path_;
+    syzygy::TBConfig syzygy_config_{};
     int numa_offset_ = 0;
     bool ponder_ = true;
     int multi_pv_ = 1;

--- a/include/engine/syzygy/syzygy.hpp
+++ b/include/engine/syzygy/syzygy.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "engine/types.hpp"
+
 #include <optional>
 #include <string>
 
@@ -17,14 +19,31 @@ enum class WdlOutcome : int {
     Win = 4
 };
 
-struct ProbeResult {
-    WdlOutcome wdl = WdlOutcome::Draw;
+struct TBConfig {
+    bool enabled = false;
+    std::string path;
+    int probe_depth = 1;
+    int probe_limit = 7;
+    bool use_rule50 = true;
 };
 
-bool init(const std::string& path);
+bool configure(const TBConfig& config);
 void shutdown();
 bool is_available();
-std::optional<ProbeResult> probe_wdl(const Board& board);
+
+namespace TB {
+
+struct ProbeResult {
+    WdlOutcome wdl = WdlOutcome::Draw;
+    std::optional<int> dtz;
+    std::optional<Move> best_move;
+};
+
+int pieceCount(const Board& board);
+std::optional<ProbeResult> probePosition(const Board& board, const TBConfig& config,
+                                         bool root);
+
+} // namespace TB
 
 } // namespace syzygy
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -12,8 +12,10 @@
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
+#include <iostream>
 #include <limits>
 #include <mutex>
+#include <sstream>
 #include <thread>
 #include <atomic>
 #include <vector>
@@ -83,6 +85,47 @@ int static_exchange_eval(const Board& board, Move move) {
     char mover = board.piece_on(move_from(move));
     int gain = piece_value(captured) - piece_value(mover);
     return gain;
+}
+
+std::string wdl_to_string(syzygy::WdlOutcome outcome) {
+    switch (outcome) {
+    case syzygy::WdlOutcome::Win: return "win";
+    case syzygy::WdlOutcome::CursedWin: return "cursed-win";
+    case syzygy::WdlOutcome::Draw: return "draw";
+    case syzygy::WdlOutcome::BlessedLoss: return "blessed-loss";
+    case syzygy::WdlOutcome::Loss: return "loss";
+    }
+    return "unknown";
+}
+
+int tablebase_score(const syzygy::TB::ProbeResult& probe,
+                    const syzygy::TBConfig& config) {
+    auto mate_score = [](bool winning, int distance) {
+        int d = std::max(1, distance);
+        int capped = std::min(kMateValue - 1, d);
+        int score = kMateValue - capped;
+        return winning ? score : -score;
+    };
+
+    switch (probe.wdl) {
+    case syzygy::WdlOutcome::Win: {
+        int dist = probe.dtz ? std::max(1, std::abs(*probe.dtz)) : 1;
+        return mate_score(true, dist);
+    }
+    case syzygy::WdlOutcome::Loss: {
+        int dist = probe.dtz ? std::max(1, std::abs(*probe.dtz)) : 1;
+        return mate_score(false, dist);
+    }
+    case syzygy::WdlOutcome::Draw:
+        return 0;
+    case syzygy::WdlOutcome::CursedWin:
+        if (config.use_rule50) return 0;
+        return mate_score(true, probe.dtz ? std::max(1, std::abs(*probe.dtz)) : 1);
+    case syzygy::WdlOutcome::BlessedLoss:
+        if (config.use_rule50) return 0;
+        return mate_score(false, probe.dtz ? std::max(1, std::abs(*probe.dtz)) : 1);
+    }
+    return 0;
 }
 
 } // namespace
@@ -270,24 +313,12 @@ void Search::set_hash(int megabytes) {
 
 void Search::stop() { stop_.store(true, std::memory_order_relaxed); }
 
-void Search::set_use_syzygy(bool enable) {
-    use_syzygy_ = enable;
-    if (!enable) {
-        syzygy::shutdown();
-    } else if (!syzygy_path_.empty()) {
-        syzygy::init(syzygy_path_);
-    }
-}
-
-void Search::set_syzygy_path(std::string path) {
-    syzygy_path_ = std::move(path);
-    if (!use_syzygy_) {
-        return;
-    }
-    if (syzygy_path_.empty()) {
+void Search::set_syzygy_config(syzygy::TBConfig config) {
+    syzygy_config_ = std::move(config);
+    if (!syzygy_config_.enabled || syzygy_config_.path.empty()) {
         syzygy::shutdown();
     } else {
-        syzygy::init(syzygy_path_);
+        syzygy::configure(syzygy_config_);
     }
 }
 
@@ -365,6 +396,43 @@ Search::Result Search::search_position(Board& board, const Limits& lim) {
 
     int depth_limit = lim.depth > 0 ? lim.depth : 64;
     depth_limit = std::min(depth_limit, 64);
+
+    int tb_limit = syzygy_config_.probe_limit;
+    if (syzygy_config_.enabled && !syzygy_config_.path.empty() &&
+        depth_limit >= syzygy_config_.probe_depth &&
+        (tb_limit < 0 || syzygy::TB::pieceCount(board) <= tb_limit)) {
+        if (auto tb = syzygy::TB::probePosition(board, syzygy_config_, true)) {
+            int tb_score = tablebase_score(*tb, syzygy_config_);
+            result.bestmove = tb->best_move.value_or(MOVE_NONE);
+            result.depth = depth_limit;
+            result.score = tb_score;
+            result.is_mate = std::abs(tb_score) >= kMateThreshold;
+            result.nodes = nodes_.load(std::memory_order_relaxed);
+            result.time_ms = static_cast<int>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - start)
+                    .count());
+            result.pv.clear();
+            if (tb->best_move) {
+                result.pv.push_back(*tb->best_move);
+            }
+
+            std::ostringstream oss;
+            oss << "info string Syzygy hit wdl " << wdl_to_string(tb->wdl);
+            if (tb->dtz) {
+                oss << " dtz " << *tb->dtz;
+            }
+            if (tb->best_move) {
+                oss << " move " << board.move_to_uci(*tb->best_move);
+            }
+            std::cout << oss.str() << '\n' << std::flush;
+
+            deadline_.reset();
+            target_time_ms_ = -1;
+            nodes_limit_ = -1;
+            return result;
+        }
+    }
 
     int aspiration_delta = kAspirationWindow;
     int fail_high_streak = 0;
@@ -553,9 +621,7 @@ int Search::negamax(Board& board, int depth, int alpha, int beta, bool pv_node, 
 
     if (depth <= 0) { return quiescence(board, alpha, beta, ply, thread_data); }
 
-    if (use_syzygy_) {
-        if (auto tb = probe_syzygy(board)) return *tb;
-    }
+    if (auto tb = probe_syzygy(board, depth, false)) return *tb;
 
     int static_eval = evaluate(board);
 
@@ -978,24 +1044,22 @@ int Search::evaluate(const Board& board) const {
     return eval::evaluate(board);
 }
 
-std::optional<int> Search::probe_syzygy(const Board& board) const {
-    if (!use_syzygy_) return std::nullopt;
-    auto result = syzygy::probe_wdl(board);
-    if (!result) return std::nullopt;
-
-    switch (result->wdl) {
-    case syzygy::WdlOutcome::Win:
-        return kMateValue - 1;
-    case syzygy::WdlOutcome::Loss:
-        return -kMateValue + 1;
-    case syzygy::WdlOutcome::Draw:
-        return 0;
-    case syzygy::WdlOutcome::CursedWin:
-        return 200;
-    case syzygy::WdlOutcome::BlessedLoss:
-        return -200;
+std::optional<int> Search::probe_syzygy(const Board& board, int depth,
+                                        bool root_probe) const {
+    if (!syzygy_config_.enabled || syzygy_config_.path.empty()) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    if (depth < syzygy_config_.probe_depth) {
+        return std::nullopt;
+    }
+    if (syzygy_config_.probe_limit >= 0 &&
+        syzygy::TB::pieceCount(board) > syzygy_config_.probe_limit) {
+        return std::nullopt;
+    }
+
+    auto probe = syzygy::TB::probePosition(board, syzygy_config_, root_probe);
+    if (!probe) return std::nullopt;
+    return tablebase_score(*probe, syzygy_config_);
 }
 
 } // namespace engine


### PR DESCRIPTION
## Summary
- add a dedicated `syzygy::TBConfig` and probing helpers that expose WDL/DTZ moves and handle tablebase initialization
- teach the searcher to store the new config, gate probes, map tablebase scores, emit `Syzygy hit` info, and exit early when a root hit is available
- extend the UCI surface with probe depth/limit and 50-move rule options that feed into the shared tablebase configuration

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d95e3130688327b767f7621dab934b