### PR TITLE
Integrate new Syzygy tablebase API

### DIFF
--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -4,8 +4,9 @@
 #include <string>
 #include <string_view>
 #include <vector>
-#include "engine/types.hpp"
 #include "engine/eval/nnue/accumulator.hpp"
+#include "engine/syzygy/tbprobe.h"
+#include "engine/types.hpp"
 
 namespace engine {
 
@@ -81,6 +82,26 @@ public:
     std::vector<Move> generate_legal_moves();
     std::string move_to_uci(Move move) const;
     Board after_move(Move move) const;
+    int countPiecesTotal() const;
+
+    struct FathomState {
+        uint64_t white = 0ULL;
+        uint64_t black = 0ULL;
+        uint64_t kings = 0ULL;
+        uint64_t queens = 0ULL;
+        uint64_t rooks = 0ULL;
+        uint64_t bishops = 0ULL;
+        uint64_t knights = 0ULL;
+        uint64_t pawns = 0ULL;
+        unsigned rule50 = 0;
+        unsigned castling = 0;
+        unsigned ep = 0;
+        bool whiteToMove = true;
+    };
+    FathomState exportToFathom() const;
+    Move convertFromTbMove(TbMove move, bool enPassantHint = false) const;
+    int plyFromRoot() const;
+    bool inCheck() const;
 
     // Accessors
     bool white_to_move() const { return stm_white_; }

--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -44,6 +44,9 @@ public:
     void stop();
     void set_use_syzygy(bool enable);
     void set_syzygy_path(std::string path);
+    void set_syzygy_probe_depth(int depth);
+    void set_syzygy_probe_limit(int limit);
+    void set_syzygy_use_rule50(bool enable);
     void set_numa_offset(int offset);
     void set_ponder(bool enable);
     void set_multi_pv(int multi_pv);
@@ -134,7 +137,8 @@ private:
     void update_history(ThreadData& thread_data, Move move, int delta);
     std::vector<Move> extract_pv(const Board& board, Move best) const;
     int evaluate(const Board& board) const;
-    std::optional<int> probe_syzygy(const Board& board) const;
+    std::optional<int> probe_syzygy(const Board& board, int depth) const;
+    void update_syzygy();
 
     std::vector<TTEntry> tt_;
     size_t tt_mask_ = 0;
@@ -148,6 +152,9 @@ private:
     int threads_ = 1;
     bool use_syzygy_ = false;
     std::string syzygy_path_;
+    int syzygy_probe_depth_ = 0;
+    int syzygy_probe_limit_ = 0;
+    bool syzygy_use_rule50_ = true;
     int numa_offset_ = 0;
     bool ponder_ = true;
     int multi_pv_ = 1;


### PR DESCRIPTION
## Summary
- replace the Syzygy interface with the new TBConfig/TBProbe API and expose probe results including move scores
- add board helpers for exporting Fathom state, translating moves, and tracking ply counts for tablebase probing
- wire UCI/search options to the new tablebase configuration and ensure initialization/release hooks are invoked

## Testing
- cmake --build build
- ctest --output-on-failure


------
https://chatgpt.com/codex/tasks/task_e_68d95e2fe6348327acd1669f66de0382