### PR TITLE
Add bench smoke test and expose UCI nps throughput

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,3 +154,7 @@ add_test(NAME go_command_responds_with_legal_move
                  $<TARGET_FILE:SirioC>
                  $<TARGET_FILE:legal_moves_cli>)
 add_test(NAME board_fen_tests COMMAND SirioCTests)
+add_test(NAME bench_smoke_test
+         COMMAND Python3::Interpreter
+                 ${CMAKE_SOURCE_DIR}/tests/test_bench.py
+                 $<TARGET_FILE:SirioC>)

--- a/README.md
+++ b/README.md
@@ -173,8 +173,10 @@ text when redistributing the engine or derivative works.
 ## Bench command
 
 SirioC exposes a `bench` command that solves a small suite of tactical
-positions at a fixed depth. The output now appears immediately so it can be
-captured by GUIs and scripts without issuing an extra command. Example usage:
+positions at a fixed depth. While searching the engine now reports the standard
+UCI `nps` field so graphical interfaces display the correct throughput, and the
+bench output can be captured by GUIs and scripts without issuing an extra
+command. Example usage:
 
 ```bash
 bench depth 8
@@ -185,3 +187,8 @@ If no explicit thread count is supplied, the command uses the current `Threads`
 UCI setting. When the option is still at its default value of 1, the engine
 automatically expands to the detected hardware concurrency so that bench runs
 exercise every core and hyper-thread.
+
+A lightweight regression test named `bench_smoke_test` is wired into the CTest
+suite. It runs `bench depth 4 threads 1` against the freshly built binary and
+verifies that the reported nodes-per-second value is positive, helping catch
+toolchain or configuration issues during compilation.

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
+#include <cstdint>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -271,8 +272,14 @@ void Uci::cmd_go(const std::string& s) {
     sync_search_options();
 
     g_search.set_info_callback([&](const Search::Info& info) {
+        uint64_t nps = 0;
+        if (info.time_ms > 0) {
+            nps = info.nodes * 1000ULL / static_cast<uint64_t>(info.time_ms);
+        }
+
         std::cout << "info depth " << info.depth << " score " << format_score(info.score)
-                  << " nodes " << info.nodes << " time " << info.time_ms << " pv";
+                  << " nodes " << info.nodes << " time " << info.time_ms << " nps " << nps
+                  << " pv";
         Board pv_board = g_board;
         std::vector<Board::State> pv_states;
         pv_states.reserve(info.pv.size());

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: test_bench.py <path-to-engine>", file=sys.stderr)
+        return 1
+
+    engine_path = Path(sys.argv[1])
+    if not engine_path.exists():
+        print(f"engine binary not found: {engine_path}", file=sys.stderr)
+        return 1
+
+    proc = subprocess.Popen(
+        [str(engine_path)], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+
+    script = "\n".join([
+        "uci",
+        "isready",
+        "bench depth 4 threads 1",
+        "quit",
+    ]) + "\n"
+
+    out, err = proc.communicate(script, timeout=15)
+
+    if proc.returncode not in (0, None):
+        raise RuntimeError(f"engine exited with code {proc.returncode}: {err}")
+
+    bench_line = None
+    for line in out.splitlines():
+        if line.startswith("bench depth"):
+            bench_line = line.strip()
+            break
+
+    if bench_line is None:
+        raise RuntimeError(f"bench command did not produce output. Output was:\n{out}")
+
+    match = re.search(r"nps (\d+)", bench_line)
+    if not match:
+        raise RuntimeError(f"bench output missing nps value: {bench_line}")
+
+    nps = int(match.group(1))
+    if nps <= 0:
+        raise RuntimeError(f"bench reported non-positive nps: {bench_line}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- report the standard UCI nps field during search so GUIs display the correct throughput
- document the behaviour and wire a bench smoke test into CTest to verify bench output

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d971d79fa4832795185907838cd984