### PR TITLE
Optimize board copies for search threads

### DIFF
--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -46,6 +46,8 @@ public:
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
     Board();
+    Board(const Board& other);
+    Board& operator=(const Board& other);
     void set_startpos();
     bool set_fen(const std::string& fen);
     bool apply_moves_uci(const std::vector<std::string>& uci_moves);

--- a/src/core/board.cpp
+++ b/src/core/board.cpp
@@ -185,6 +185,37 @@ bool parse_en_passant_field(const std::string& field, int& square) {
 
 Board::Board() { set_startpos(); }
 
+Board::Board(const Board& other)
+    : stm_white_(other.stm_white_),
+      piece_bitboards_(other.piece_bitboards_),
+      occupancy_(other.occupancy_),
+      castling_rights_(other.castling_rights_),
+      en_passant_square_(other.en_passant_square_),
+      halfmove_clock_(other.halfmove_clock_),
+      fullmove_number_(other.fullmove_number_),
+      last_fen_(other.last_fen_),
+      squares_(other.squares_),
+      accumulator_(other.accumulator_),
+      history_() {}
+
+Board& Board::operator=(const Board& other) {
+    if (this == &other) return *this;
+
+    stm_white_ = other.stm_white_;
+    piece_bitboards_ = other.piece_bitboards_;
+    occupancy_ = other.occupancy_;
+    castling_rights_ = other.castling_rights_;
+    en_passant_square_ = other.en_passant_square_;
+    halfmove_clock_ = other.halfmove_clock_;
+    fullmove_number_ = other.fullmove_number_;
+    last_fen_ = other.last_fen_;
+    squares_ = other.squares_;
+    accumulator_ = other.accumulator_;
+    history_.clear();
+
+    return *this;
+}
+
 void Board::set_startpos() { set_fen(std::string(kStartposFEN)); }
 
 bool Board::set_fen(const std::string& fen) {


### PR DESCRIPTION
## Summary
- add explicit copy constructor and assignment operator for `Board`
- avoid copying the move history vector when cloning board instances used by search threads

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build -j
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d976c2a2a48327a09eaa5cfdc92773