### PR TITLE
Refactor node counting to per-thread aggregation

### DIFF
--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -15,6 +15,8 @@
 #include <vector>
 #include <mutex>
 
+#include "engine/util/nodes.hpp"
+
 namespace engine {
 class Board;
 namespace nnue {
@@ -75,6 +77,7 @@ private:
         std::vector<std::array<Move, 2>> killers;
         std::array<int, 64 * 64> history{};
         std::array<Move, 64 * 64> countermoves{};
+        size_t id = 0;
     };
     struct AdaptiveTuning {
         void reset();
@@ -144,7 +147,7 @@ private:
     std::vector<TTEntry> tt_;
     size_t tt_mask_ = 0;
     mutable std::shared_mutex tt_mutex_;
-    std::atomic<uint64_t> nodes_;
+    NodesCounter nodes_;
     std::atomic<bool> stop_;
     std::vector<ThreadData> thread_data_pool_;
     uint64_t thread_data_position_key_ = 0;

--- a/include/engine/util/nodes.hpp
+++ b/include/engine/util/nodes.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace engine {
+
+// Lightweight per-thread node counter with relaxed aggregation.
+class NodesCounter {
+public:
+    NodesCounter() = default;
+
+    void configure(size_t threads) {
+        if (locals_.size() != threads) {
+            locals_.assign(threads, 0);
+        } else {
+            std::fill(locals_.begin(), locals_.end(), 0);
+        }
+        total_.store(0, std::memory_order_relaxed);
+    }
+
+    uint64_t increment(size_t thread_index, uint64_t delta = 1) {
+        if (thread_index >= locals_.size()) {
+            return total_.fetch_add(delta, std::memory_order_relaxed) + delta;
+        }
+        locals_[thread_index] += delta;
+        return total_.fetch_add(delta, std::memory_order_relaxed) + delta;
+    }
+
+    uint64_t total_nodes() const { return total_.load(std::memory_order_relaxed); }
+
+private:
+    std::vector<uint64_t> locals_{};
+    std::atomic<uint64_t> total_{0};
+};
+
+} // namespace engine
+


### PR DESCRIPTION
## Summary
- add a lightweight per-thread node counter helper with relaxed aggregation semantics
- refactor the search logic to use the new counter, wiring thread ids through thread data and reporting totals via total_nodes()

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d9823afe8c8327870ad79aa4705c5f