### PR TITLE
Add bench suite and UCI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if (ENABLE_LTO)
 endif()
 
 set(SIRIOC_SOURCES
+  ${CMAKE_SOURCE_DIR}/src/bench.cpp
   ${CMAKE_SOURCE_DIR}/src/core/board.cpp
   ${CMAKE_SOURCE_DIR}/src/core/fen.cpp
   ${CMAKE_SOURCE_DIR}/src/core/movegen.cpp

--- a/include/engine/bench/bench.hpp
+++ b/include/engine/bench/bench.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+
+namespace engine {
+
+class Search;
+
+namespace bench {
+
+struct BenchResult {
+    uint64_t nodes = 0;
+    int time_ms = 0;
+    int depth = 0;
+    int positions = 0;
+};
+
+struct PerftResult {
+    uint64_t nodes = 0;
+    int time_ms = 0;
+    int depth = 0;
+    int positions = 0;
+    bool verified = false;
+};
+
+BenchResult run(Search& search, int depth);
+PerftResult run_perft_suite(int depth);
+
+} // namespace bench
+
+} // namespace engine
+

--- a/src/bench.cpp
+++ b/src/bench.cpp
@@ -1,0 +1,117 @@
+#include "engine/bench/bench.hpp"
+
+#include "engine/core/board.hpp"
+#include "engine/core/perft.hpp"
+#include "engine/search/search.hpp"
+#include "engine/types.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace engine::bench {
+
+namespace {
+
+struct BenchEntry {
+    std::string_view fen;
+};
+
+struct PerftEntry {
+    std::string_view fen;
+    std::vector<std::pair<int, uint64_t>> reference;
+};
+
+const std::array<BenchEntry, 8>& bench_suite() {
+    static const std::array<BenchEntry, 8> suite = { {
+        {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"},
+        {"rnbq1k1r/pp3ppp/2p2n2/3p4/3P4/2N1PN2/PP3PPP/R1BQKB1R w KQ - 0 8"},
+        {"r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P3/2NP1N2/PPP2PPP/2KR3R w - - 0 10"},
+        {"4rrk1/pp3ppp/2p2n2/3p4/3P4/2N1PN2/PP3PPP/R4RK1 w - - 0 15"},
+        {"1r3rk1/5pp1/p1npbn1p/q1p1p3/2P1P3/1PN1BP2/PB3P1P/2RQ1RK1 w - - 0 17"},
+        {"r2q1rk1/pp2bppp/1np1pn2/8/2PN4/2N1BP2/PP3PPP/R2Q1RK1 w - - 0 10"},
+        {"r1bq1rk1/ppp1ppbp/2np1np1/8/2PP4/2N1PN2/PP2BPPP/R1BQ1RK1 w - - 0 8"},
+        {"r4rk1/1pp2ppp/p1npbn2/2b1p3/2B1P3/2NP1N2/PPP2PPP/2KR3R w - - 0 12"},
+    } };
+    return suite;
+}
+
+const std::array<PerftEntry, 3>& perft_suite() {
+    static const std::array<PerftEntry, 3> suite = { {
+        {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+         {{1, 20ULL}, {2, 400ULL}, {3, 8902ULL}, {4, 197281ULL}, {5, 4865609ULL}}},
+        {"r3k2r/p1ppqpb1/bn2pnp1/2Pp4/1p2P3/2N2N2/PPQ1BPPP/R3K2R w KQkq - 0 1",
+         {{1, 48ULL}, {2, 2039ULL}, {3, 97862ULL}, {4, 4085603ULL}, {5, 193690690ULL}}},
+        {"8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1",
+         {{1, 14ULL}, {2, 191ULL}, {3, 2812ULL}, {4, 43238ULL}, {5, 674624ULL}, {6, 11030083ULL}}},
+    } };
+    return suite;
+}
+
+} // namespace
+
+BenchResult run(Search& search, int depth) {
+    BenchResult result;
+    result.depth = depth;
+    const auto& suite = bench_suite();
+    result.positions = static_cast<int>(suite.size());
+
+    Board board;
+    auto start = std::chrono::steady_clock::now();
+    for (const auto& entry : suite) {
+        if (!board.set_fen(std::string(entry.fen))) {
+            continue;
+        }
+        Limits limits;
+        limits.depth = depth;
+        limits.nodes = std::max<int64_t>(20000, static_cast<int64_t>(depth) * 12500);
+        auto search_result = search.find_bestmove(board, limits);
+        result.nodes += search_result.nodes;
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    result.time_ms = static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+    return result;
+}
+
+PerftResult run_perft_suite(int depth) {
+    PerftResult result;
+    result.depth = depth;
+    const auto& suite = perft_suite();
+    result.positions = static_cast<int>(suite.size());
+
+    Board board;
+    auto start = std::chrono::steady_clock::now();
+    bool verified = true;
+    for (const auto& entry : suite) {
+        if (!board.set_fen(std::string(entry.fen))) {
+            verified = false;
+            continue;
+        }
+        uint64_t nodes = perft(board, depth);
+        result.nodes += nodes;
+
+        bool matched = false;
+        for (const auto& [ref_depth, ref_nodes] : entry.reference) {
+            if (ref_depth == depth) {
+                matched = (ref_nodes == nodes);
+                break;
+            }
+        }
+        if (!matched) {
+            verified = false;
+        }
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    result.time_ms = static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+    result.verified = verified;
+    return result;
+}
+
+} // namespace engine::bench
+

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -1,5 +1,7 @@
 #include "engine/uci/uci.hpp"
 
+#include "engine/bench/bench.hpp"
+
 #include "engine/config.hpp"
 #include "engine/core/board.hpp"
 #include "engine/core/fen.hpp"
@@ -366,29 +368,34 @@ void Uci::cmd_bench(const std::string& s) {
     auto tokens = split(s);
     int depth = 8;
     int threads = g_threads;
+    bool perft_mode = false;
     for (size_t i = 1; i < tokens.size(); ++i) {
         if (tokens[i] == "depth" && i + 1 < tokens.size()) depth = std::stoi(tokens[i + 1]);
-        if (tokens[i] == "threads" && i + 1 < tokens.size()) threads = std::stoi(tokens[i + 1]);
+        else if (tokens[i] == "threads" && i + 1 < tokens.size()) threads = std::stoi(tokens[i + 1]);
+        else if (tokens[i] == "perft") perft_mode = true;
     }
 
     int previous_threads = g_threads;
     g_threads = std::clamp(threads, 1, kThreadsMax);
     sync_search_options();
 
-    Limits lim;
-    lim.depth = depth;
-
-    auto start = std::chrono::steady_clock::now();
-    auto result = g_search.find_bestmove(g_board, lim);
-    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::steady_clock::now() - start)
-                          .count();
-
-    std::cout << "bench depth " << depth << " nodes " << result.nodes << " time " << elapsed_ms
-              << " nps "
-              << (elapsed_ms > 0 ? result.nodes * 1000ULL / static_cast<uint64_t>(elapsed_ms)
-                                 : 0)
-              << "\n";
+    if (perft_mode) {
+        auto result = bench::run_perft_suite(depth);
+        uint64_t nps = result.time_ms > 0
+                            ? result.nodes * 1000ULL / static_cast<uint64_t>(result.time_ms)
+                            : 0;
+        std::cout << "bench perft depth " << depth << " nodes " << result.nodes << " time "
+                  << result.time_ms << " nps " << nps << " positions " << result.positions
+                  << " verified " << (result.verified ? "true" : "false") << "\n";
+    } else {
+        auto result = bench::run(g_search, depth);
+        uint64_t nps = result.time_ms > 0
+                            ? result.nodes * 1000ULL / static_cast<uint64_t>(result.time_ms)
+                            : 0;
+        std::cout << "bench depth " << depth << " nodes " << result.nodes << " time "
+                  << result.time_ms << " nps " << nps << " positions " << result.positions
+                  << "\n";
+    }
 
     g_threads = previous_threads;
     sync_search_options();


### PR DESCRIPTION
## Summary
- add a dedicated bench/perft module with curated suites and node budgets
- extend the UCI bench command to call the new helpers and report positions as well as perft verification
- include the new source in the core target so bench is available in regular builds

## Testing
- ctest --test-dir build --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d984ced6748327a738f99290216536