### PR TITLE
Integrate incremental Zobrist hashing

### DIFF
--- a/include/engine/core/board.hpp
+++ b/include/engine/core/board.hpp
@@ -72,6 +72,7 @@ public:
         int prev_mg = 0;
         int prev_eg = 0;
         int prev_phase = 0;
+        uint64_t prev_zobrist_key = 0ULL;
     };
 
     bool make_move(Move m);
@@ -128,6 +129,11 @@ private:
     static int to_index(int file, int rank);
     std::string square_to_string(int sq) const;
     char promotion_from_code(int code, bool white) const;
+    uint64_t compute_zobrist_key() const;
+    static const std::array<uint64_t, 12 * 64>& zobrist_piece_keys();
+    static const std::array<uint64_t, 16>& zobrist_castling_keys();
+    static const std::array<uint64_t, 8>& zobrist_enpassant_keys();
+    static uint64_t zobrist_side_key();
 
     bool stm_white_ = true;
     std::array<uint64_t, PIECE_NB> piece_bitboards_{};
@@ -140,6 +146,7 @@ private:
     std::array<char, 64> squares_{};
     nnue::Accumulator accumulator_{};
     std::vector<State> history_{};
+    uint64_t zobrist_key_ = 0ULL;
 };
 
 } // namespace engine


### PR DESCRIPTION
## Summary
- maintain an incremental Zobrist key on the board state and store it in move history
- expose the Zobrist random tables for reuse when updating the board incrementally
- recompute the key when loading a FEN and copy it across board copies

## Testing
- cmake --build build -j

------
https://chatgpt.com/codex/tasks/task_e_68d988df4c508327962660d6a7a9938f