### PR TITLE
Fix UCI stop handling with asynchronous search thread

### DIFF
--- a/include/engine/uci/uci.hpp
+++ b/include/engine/uci/uci.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <thread>
 
 namespace engine {
 
@@ -19,6 +20,10 @@ private:
     void cmd_stop();
     void cmd_perft(const std::string& s);
     void cmd_bench(const std::string& s);
+
+    void stop_search_thread();
+
+    std::thread search_thread_{};
 };
 
 } // namespace engine


### PR DESCRIPTION
## Summary
- launch searches on a dedicated background thread using a board snapshot and wait for the worker to start before returning from `go`
- add a shared stop helper and invoke it from UCI commands so `stop`, `position`, `isready`, and other commands can safely cancel or join a running analysis

## Testing
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68d99a4d9a6c83278f26b2bc5a6e267e