### PR TITLE
Fix UCI bestmove output for no-legal-move positions

### DIFF
--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -375,7 +375,13 @@ void Uci::cmd_go(const std::string& s) {
         g_search.set_info_callback(nullptr);
 
         if (result.bestmove == MOVE_NONE) {
-            std::cout << "bestmove (none)\n";
+            // UCI requires engines with no legal moves to report "bestmove 0000"
+            // (or "null") so that GUIs treat the search as finished instead of
+            // assuming the engine disconnected. Emitting the literal string
+            // "(none)" caused relay servers to drop SirioC after checkmates or
+            // stalemates, producing forfeits despite the engine completing the
+            // search. Use the standard 0000 placeholder to remain compliant.
+            std::cout << "bestmove 0000\n";
         } else {
             std::cout << "bestmove " << board_copy.move_to_uci(result.bestmove) << "\n";
         }

--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -57,9 +57,9 @@ def assert_bestmove_is_legal(engine_path, helper_path, fen, position_cmd, expect
             raise AssertionError(
                 f"Expected no legal moves but helper produced: {moves}\nPosition: {position_cmd}"
             )
-        if bestmove != "(none)":
+        if bestmove not in {"0000", "(none)"}:
             raise AssertionError(
-                f"Engine should report (none) but returned {bestmove}\nOutput:\n{output}"
+                f"Engine should report 0000 (or historical (none)) but returned {bestmove}\nOutput:\n{output}"
             )
         return
 


### PR DESCRIPTION
## Summary
- emit `bestmove 0000` when the search has no legal moves so GUIs do not drop the engine
- relax the go command test to accept the UCI-compliant 0000 placeholder

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d99f6643b48327b2838dee4471d999