### PR TITLE
Refine quiescence search with SEE ordering

### DIFF
--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -68,9 +68,16 @@ private:
 
         static constexpr int kMaxPly = 128;
 
+        struct QuiescenceCapture {
+            Move move = MOVE_NONE;
+            int see = 0;
+        };
+
         std::vector<std::array<Move, 2>> killers;
         std::array<int, 64 * 64> history{};
         std::array<Move, 64 * 64> countermoves{};
+        std::vector<QuiescenceCapture> quiescence_captures;
+        std::vector<Move> quiescence_checks;
         size_t id = 0;
     };
     struct AdaptiveTuning {

--- a/include/engine/search/see.hpp
+++ b/include/engine/search/see.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "engine/types.hpp"
+
+namespace engine {
+
+class Board;
+
+int static_exchange_eval(const Board& board, Move move);
+
+} // namespace engine


### PR DESCRIPTION
## Summary
- add the SEE declaration and wrapper so static exchange evaluations can be reused outside the search translation unit
- extend thread-local data with quiescence buffers and refactor quiescence search to score captures by SEE while filtering losing moves
- only continue from checking quiet moves after the capture pass to avoid duplicates and respect node accounting

## Testing
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d9b36e0aa883278be4900f664d441a