### PR TITLE
Track tablebase hits in search info

### DIFF
--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -41,6 +41,7 @@ public:
         int score = 0;
         uint64_t nodes = 0;
         int time_ms = 0;
+        uint64_t tbhits = 0;
         std::vector<Move> pv;
     };
 
@@ -150,6 +151,7 @@ private:
 
     TranspositionTable tt_;
     std::atomic<bool> stop_;
+    mutable std::atomic<uint64_t> tb_hits_{0};
     std::vector<ThreadData> thread_data_pool_;
     uint64_t thread_data_position_key_ = 0;
     size_t thread_data_thread_count_ = 0;

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -819,6 +819,7 @@ Search::Result Search::search_position(Board& board, const Limits& lim) {
     Result result;
     auto start = std::chrono::steady_clock::now();
     search_start_ = start;
+    tb_hits_.store(0, std::memory_order_relaxed);
 
     size_t thread_count = static_cast<size_t>(std::max(1, threads_));
     bool thread_count_changed = thread_data_thread_count_ != thread_count;
@@ -1060,6 +1061,7 @@ Search::Result Search::search_position(Board& board, const Limits& lim) {
                         std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::steady_clock::now() - start)
                             .count());
+                    info.tbhits = tb_hits_.load(std::memory_order_relaxed);
                     info.pv = extract_pv(board, best_move);
                     info_callback_(info);
                 }
@@ -1569,6 +1571,7 @@ std::optional<int> Search::probe_syzygy(const Board& board, int depth,
 
     auto probe = syzygy::TB::probePosition(board, syzygy_config_, root_probe);
     if (!probe) return std::nullopt;
+    tb_hits_.fetch_add(1, std::memory_order_relaxed);
     return tablebase_score(*probe, syzygy_config_);
 }
 

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -387,6 +387,9 @@ void Uci::cmd_go(const std::string& s) {
             std::cout << "info depth " << lite.depth << " score " << format_score(lite.score)
                       << " nodes " << lite.nodes << " time " << lite.time_ms << " nps "
                       << lite.nps;
+            if (info.tbhits > 0) {
+                std::cout << " tbhits " << info.tbhits;
+            }
             if (!lite.pv.empty()) {
                 std::cout << " pv " << lite.pv;
             }


### PR DESCRIPTION
## Summary
- add a tablebase hit counter in the search info structure
- increment the counter when Syzygy probes succeed and expose it via the info callback
- display the counter in UCI info output when any tablebase hits occurred

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9bdb190d083278279c6b2e0564360