### PR TITLE
Report transposition table hash usage to UCI

### DIFF
--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -41,6 +41,7 @@ public:
         int score = 0;
         uint64_t nodes = 0;
         int time_ms = 0;
+        int hashfull = -1;
         std::vector<Move> pv;
     };
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1060,6 +1060,7 @@ Search::Result Search::search_position(Board& board, const Limits& lim) {
                         std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::steady_clock::now() - start)
                             .count());
+                    info.hashfull = tt_.empty() ? -1 : tt_.hashfull();
                     info.pv = extract_pv(board, best_move);
                     info_callback_(info);
                 }

--- a/src/tt.h
+++ b/src/tt.h
@@ -20,6 +20,7 @@ public:
                int& stored_depth, int& flag, int& eval) const;
     void store(uint64_t key, Move move, int depth, int score, int flag, int ply, int eval);
     Move probe_move(uint64_t key) const;
+    int hashfull() const;
 
     bool empty() const { return entry_count_ == 0 || !entries_; }
 

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -75,6 +75,7 @@ struct UciLiteInfo {
     uint64_t nodes = 0;
     uint64_t nps = 0;
     int time_ms = 0;
+    int hashfull = -1;
     std::string pv;
 };
 
@@ -382,11 +383,15 @@ void Uci::cmd_go(const std::string& s) {
             lite.nps = info.time_ms > 0
                            ? info.nodes * 1000ULL / static_cast<uint64_t>(info.time_ms)
                            : 0;
+            lite.hashfull = info.hashfull;
             lite.pv = pv_to_string(board_copy, info.pv);
 
             std::cout << "info depth " << lite.depth << " score " << format_score(lite.score)
                       << " nodes " << lite.nodes << " time " << lite.time_ms << " nps "
                       << lite.nps;
+            if (lite.hashfull >= 0) {
+                std::cout << " hashfull " << lite.hashfull;
+            }
             if (!lite.pv.empty()) {
                 std::cout << " pv " << lite.pv;
             }


### PR DESCRIPTION
## Summary
- add a hashfull field to search info and plumb it through the UCI reporting path
- implement TranspositionTable::hashfull() to estimate recent entry usage based on entry generations
- include the hashfull metric in "info" responses when available

## Testing
- cmake --build build
- ctest --test-dir build -j4

------
https://chatgpt.com/codex/tasks/task_e_68d9bdaefa0c8327847eb747bdaed13a