### PR TITLE
Clean up merge artifacts breaking the build

### DIFF
--- a/include/engine/search/search.hpp
+++ b/include/engine/search/search.hpp
@@ -41,11 +41,8 @@ public:
         int score = 0;
         uint64_t nodes = 0;
         int time_ms = 0;
- codex/expand-engine-search-info-for-hashfull
         int hashfull = -1;
-
         uint64_t tbhits = 0;
- main
         std::vector<Move> pv;
     };
 

--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1061,11 +1061,8 @@ Search::Result Search::search_position(Board& board, const Limits& lim) {
                         std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::steady_clock::now() - start)
                             .count());
-codex/expand-engine-search-info-for-hashfull
                     info.hashfull = tt_.empty() ? -1 : tt_.hashfull();
-
                     info.tbhits = tb_hits_.load(std::memory_order_relaxed);
- main
                     info.pv = extract_pv(board, best_move);
                     info_callback_(info);
                 }

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -389,13 +389,11 @@ void Uci::cmd_go(const std::string& s) {
             std::cout << "info depth " << lite.depth << " score " << format_score(lite.score)
                       << " nodes " << lite.nodes << " time " << lite.time_ms << " nps "
                       << lite.nps;
- codex/expand-engine-search-info-for-hashfull
             if (lite.hashfull >= 0) {
                 std::cout << " hashfull " << lite.hashfull;
-=======
+            }
             if (info.tbhits > 0) {
                 std::cout << " tbhits " << info.tbhits;
- main
             }
             if (!lite.pv.empty()) {
                 std::cout << " pv " << lite.pv;


### PR DESCRIPTION
## Summary
- remove merge artefacts from Search::Info so hashfull/tbhits fields compile again
- restore the search info publisher to emit hashfull/tbhits without stray tokens

## Testing
- cmake --build build -j
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68d9bf87ffd0832797b8a47c87bce41e