### PR TITLE
Validate PV moves against legality

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -1580,7 +1580,11 @@ std::vector<Move> Search::extract_pv(const Board& board, Move best) const {
         uint64_t key = current.zobrist_key();
         Move next = tt_.probe_move(key);
         if (next == MOVE_NONE) break;
+
+        auto legal_moves = current.generate_legal_moves();
+        if (std::find(legal_moves.begin(), legal_moves.end(), next) == legal_moves.end()) break;
         if (std::find(pv.begin(), pv.end(), next) != pv.end()) break;
+
         pv.push_back(next);
         Board::State next_state;
         current.apply_move(next, next_state);


### PR DESCRIPTION
## Summary
- ensure PV extraction only follows transposition table moves that are legal in the current position to avoid illegal PV output

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d9c87d4f08832798ea8190b53079ab