### PR TITLE
Fix NNUE build without exceptions

### DIFF
--- a/3rdparty/jdart_nnue/util.h
+++ b/3rdparty/jdart_nnue/util.h
@@ -32,20 +32,19 @@ static uint64_t to_little_endian64(uint64_t x) { return (x); }
 #endif
 
 template <typename T> T read_little_endian(std::istream &s) {
+    static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8,
+                  "unsupported size");
     char buf[sizeof(T)];
     s.read(buf, sizeof(T));
     T input = *(reinterpret_cast<T *>(buf));
-    switch (sizeof(T)) {
-    case 1:
+    if constexpr (sizeof(T) == 1) {
         return static_cast<T>(input);
-    case 2:
+    } else if constexpr (sizeof(T) == 2) {
         return static_cast<T>(to_little_endian16(input));
-    case 4:
+    } else if constexpr (sizeof(T) == 4) {
         return static_cast<T>(to_little_endian32(input));
-    case 8:
+    } else { // sizeof(T) == 8
         return static_cast<T>(to_little_endian64(input));
-    default:
-        throw std::invalid_argument("unsupported size");
     }
 }
 

--- a/include/engine/eval/nnue/evaluator.hpp
+++ b/include/engine/eval/nnue/evaluator.hpp
@@ -12,6 +12,7 @@ namespace engine::nnue {
 class Evaluator {
 public:
     Evaluator();
+    ~Evaluator();
 
     bool load_network(const std::string& path);
     int eval_cp(const engine::Board& board) const;

--- a/src/eval/nnue/evaluator.cpp
+++ b/src/eval/nnue/evaluator.cpp
@@ -3,7 +3,7 @@
 #include "engine/core/board.hpp"
 #include "engine/eval/nnue/accumulator.hpp"
 
-#include "3rdparty/jdart_nnue/nnue.h"
+#include "nnue.h"
 
 #include <array>
 #include <fstream>
@@ -82,6 +82,8 @@ private:
 } // namespace
 
 Evaluator::Evaluator() = default;
+
+Evaluator::~Evaluator() = default;
 
 bool Evaluator::load_network(const std::string& path) {
     std::ifstream file(path, std::ios::binary);


### PR DESCRIPTION
## Summary
- include the embedded NNUE header via the configured include directory
- provide an out-of-line evaluator destructor so the NNUE network type is complete when destroyed
- replace the NNUE utility throw with a static assertion to keep builds working without exceptions

## Testing
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68d9ce2a23048327b9e5caa53cec1086