### PR TITLE
Add foundational engine source stubs

### DIFF
--- a/src/attacks.c
+++ b/src/attacks.c
@@ -1,0 +1,165 @@
+#include "attacks.h"
+
+#include <stddef.h>
+
+static Bitboard g_knight_attacks[64];
+static Bitboard g_king_attacks[64];
+static Bitboard g_pawn_attacks[COLOR_NB][64];
+
+static Bitboard mask_knight(Square square) {
+    const int file = square % 8;
+    const int rank = square / 8;
+    Bitboard attacks = 0ULL;
+
+    const int offsets[8][2] = {
+        {1, 2}, {2, 1}, {-1, 2}, {-2, 1},
+        {1, -2}, {2, -1}, {-1, -2}, {-2, -1}
+    };
+
+    for (size_t i = 0; i < 8; ++i) {
+        int nf = file + offsets[i][0];
+        int nr = rank + offsets[i][1];
+        if (nf >= 0 && nf < 8 && nr >= 0 && nr < 8) {
+            attacks |= 1ULL << (nr * 8 + nf);
+        }
+    }
+    return attacks;
+}
+
+static Bitboard mask_king(Square square) {
+    const int file = square % 8;
+    const int rank = square / 8;
+    Bitboard attacks = 0ULL;
+
+    for (int df = -1; df <= 1; ++df) {
+        for (int dr = -1; dr <= 1; ++dr) {
+            if (df == 0 && dr == 0) {
+                continue;
+            }
+            int nf = file + df;
+            int nr = rank + dr;
+            if (nf >= 0 && nf < 8 && nr >= 0 && nr < 8) {
+                attacks |= 1ULL << (nr * 8 + nf);
+            }
+        }
+    }
+
+    return attacks;
+}
+
+static Bitboard mask_pawn(Square square, enum Color color) {
+    const int file = square % 8;
+    const int rank = square / 8;
+    Bitboard attacks = 0ULL;
+
+    int forward = (color == COLOR_WHITE) ? 1 : -1;
+
+    int nf = file - 1;
+    int nr = rank + forward;
+    if (nf >= 0 && nf < 8 && nr >= 0 && nr < 8) {
+        attacks |= 1ULL << (nr * 8 + nf);
+    }
+
+    nf = file + 1;
+    nr = rank + forward;
+    if (nf >= 0 && nf < 8 && nr >= 0 && nr < 8) {
+        attacks |= 1ULL << (nr * 8 + nf);
+    }
+
+    return attacks;
+}
+
+void attacks_init(void) {
+    for (Square sq = 0; sq < 64; ++sq) {
+        g_knight_attacks[sq] = mask_knight(sq);
+        g_king_attacks[sq] = mask_king(sq);
+        g_pawn_attacks[COLOR_WHITE][sq] = mask_pawn(sq, COLOR_WHITE);
+        g_pawn_attacks[COLOR_BLACK][sq] = mask_pawn(sq, COLOR_BLACK);
+    }
+}
+
+Bitboard attacks_knight(Square square) {
+    if (square < 0 || square >= 64) {
+        return 0ULL;
+    }
+    return g_knight_attacks[square];
+}
+
+Bitboard attacks_king(Square square) {
+    if (square < 0 || square >= 64) {
+        return 0ULL;
+    }
+    return g_king_attacks[square];
+}
+
+Bitboard attacks_pawn(Square square, enum Color color) {
+    if (square < 0 || square >= 64 || color < 0 || color >= COLOR_NB) {
+        return 0ULL;
+    }
+    return g_pawn_attacks[color][square];
+}
+
+Bitboard attacks_bishop(Square square, Bitboard occupancy) {
+    (void)occupancy;
+    if (square < 0 || square >= 64) {
+        return 0ULL;
+    }
+
+    Bitboard attacks = 0ULL;
+    int file = square % 8;
+    int rank = square / 8;
+
+    for (int df = -1; df <= 1; df += 2) {
+        for (int dr = -1; dr <= 1; dr += 2) {
+            int nf = file + df;
+            int nr = rank + dr;
+            while (nf >= 0 && nf < 8 && nr >= 0 && nr < 8) {
+                attacks |= 1ULL << (nr * 8 + nf);
+                nf += df;
+                nr += dr;
+            }
+        }
+    }
+
+    return attacks;
+}
+
+Bitboard attacks_rook(Square square, Bitboard occupancy) {
+    (void)occupancy;
+    if (square < 0 || square >= 64) {
+        return 0ULL;
+    }
+
+    Bitboard attacks = 0ULL;
+    int file = square % 8;
+    int rank = square / 8;
+
+    for (int df = -1; df <= 1; ++df) {
+        if (df == 0) {
+            continue;
+        }
+        int nf = file + df;
+        while (nf >= 0 && nf < 8) {
+            attacks |= 1ULL << (rank * 8 + nf);
+            nf += df;
+        }
+    }
+
+    for (int dr = -1; dr <= 1; ++dr) {
+        if (dr == 0) {
+            continue;
+        }
+        int nr = rank + dr;
+        while (nr >= 0 && nr < 8) {
+            attacks |= 1ULL << (nr * 8 + file);
+            nr += dr;
+        }
+    }
+
+    return attacks;
+}
+
+Bitboard attacks_queen(Square square, Bitboard occupancy) {
+    return attacks_bishop(square, occupancy) | attacks_rook(square, occupancy);
+}
+

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void attacks_init(void);
+Bitboard attacks_knight(Square square);
+Bitboard attacks_king(Square square);
+Bitboard attacks_pawn(Square square, enum Color color);
+Bitboard attacks_bishop(Square square, Bitboard occupancy);
+Bitboard attacks_rook(Square square, Bitboard occupancy);
+Bitboard attacks_queen(Square square, Bitboard occupancy);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/bench.c
+++ b/src/bench.c
@@ -1,0 +1,14 @@
+#include "bench.h"
+
+#include <stdio.h>
+
+void bench_run(SearchContext* context) {
+    if (context == NULL) {
+        return;
+    }
+
+    SearchLimits limits = { .depth = 1, .movetime_ms = 0, .nodes = 0, .infinite = 0 };
+    Move move = search_iterative_deepening(context, &limits);
+    printf("bench bestmove %d%d value %d\n", move.from, move.to, context->best_value);
+}
+

--- a/src/bench.h
+++ b/src/bench.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "search.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void bench_run(SearchContext* context);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/berserk.c
+++ b/src/berserk.c
@@ -1,0 +1,7 @@
+#include "berserk.h"
+
+int berserk_run(SearchContext* context) {
+    bench_run(context);
+    return 0;
+}
+

--- a/src/berserk.h
+++ b/src/berserk.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "bench.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int berserk_run(SearchContext* context);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/bits.c
+++ b/src/bits.c
@@ -1,0 +1,48 @@
+#include "bits.h"
+
+#if defined(__GNUC__)
+#include <x86intrin.h>
+#endif
+
+int bits_count(Bitboard bb) {
+#if defined(__GNUC__)
+    return __builtin_popcountll(bb);
+#else
+    int count = 0;
+    while (bb) {
+        bb &= bb - 1;
+        ++count;
+    }
+    return count;
+#endif
+}
+
+int bits_popcount(Bitboard bb) {
+    return bits_count(bb);
+}
+
+Square bits_ls1b(Bitboard bb) {
+    if (bb == 0) {
+        return -1;
+    }
+#if defined(__GNUC__)
+    return (Square)__builtin_ctzll(bb);
+#else
+    Square index = 0;
+    while ((bb & 1ULL) == 0ULL) {
+        bb >>= 1ULL;
+        ++index;
+    }
+    return index;
+#endif
+}
+
+Bitboard bits_pop_lsb(Bitboard* bb) {
+    if (bb == NULL || *bb == 0ULL) {
+        return 0ULL;
+    }
+    Bitboard lsb = *bb & -(*bb);
+    *bb &= *bb - 1ULL;
+    return lsb;
+}
+

--- a/src/bits.h
+++ b/src/bits.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int bits_count(Bitboard bb);
+int bits_popcount(Bitboard bb);
+Square bits_ls1b(Bitboard bb);
+Bitboard bits_pop_lsb(Bitboard* bb);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/board.c
+++ b/src/board.c
@@ -1,0 +1,146 @@
+#include "board.h"
+#include "bits.h"
+
+#include <string.h>
+
+void board_init(Board* board) {
+    if (board == NULL) {
+        return;
+    }
+    memset(board, 0, sizeof(*board));
+    board->en_passant_square = -1;
+    board->side_to_move = COLOR_WHITE;
+}
+
+static void set_piece(Board* board, Square square, Piece piece, enum Color color) {
+    board->squares[square] = piece;
+    board->bitboards[piece + PIECE_TYPE_NB * color] |= 1ULL << square;
+}
+
+void board_set_start_position(Board* board) {
+    board_init(board);
+    if (board == NULL) {
+        return;
+    }
+
+    for (int i = 8; i < 16; ++i) {
+        set_piece(board, i, PIECE_PAWN, COLOR_WHITE);
+        set_piece(board, 48 + (i - 8), PIECE_PAWN, COLOR_BLACK);
+    }
+
+    const Piece white_back_rank[8] = {
+        PIECE_ROOK, PIECE_KNIGHT, PIECE_BISHOP, PIECE_QUEEN,
+        PIECE_KING, PIECE_BISHOP, PIECE_KNIGHT, PIECE_ROOK
+    };
+
+    for (int file = 0; file < 8; ++file) {
+        set_piece(board, file, white_back_rank[file], COLOR_WHITE);
+        set_piece(board, 56 + file, white_back_rank[file], COLOR_BLACK);
+    }
+
+    board->side_to_move = COLOR_WHITE;
+    board->castling_rights = 0xF;
+    board->en_passant_square = -1;
+    board->halfmove_clock = 0;
+    board->fullmove_number = 1;
+}
+
+Bitboard board_occupancy(const Board* board, enum Color color) {
+    if (board == NULL || color < 0 || color >= COLOR_NB) {
+        return 0ULL;
+    }
+
+    Bitboard occupancy = 0ULL;
+    for (int pt = PIECE_PAWN; pt < PIECE_TYPE_NB; ++pt) {
+        occupancy |= board->bitboards[pt + PIECE_TYPE_NB * color];
+    }
+    return occupancy;
+}
+
+int board_is_square_attacked(const Board* board, Square square, enum Color attacker) {
+    if (board == NULL) {
+        return 0;
+    }
+
+    Bitboard occ = board_occupancy(board, COLOR_WHITE) | board_occupancy(board, COLOR_BLACK);
+
+    Bitboard knights = board->bitboards[PIECE_KNIGHT + PIECE_TYPE_NB * attacker];
+    for (Bitboard bb = knights; bb; bb &= bb - 1ULL) {
+        Square sq = bits_ls1b(bb);
+        if (attacks_knight(sq) & (1ULL << square)) {
+            return 1;
+        }
+    }
+
+    Bitboard bishops = board->bitboards[PIECE_BISHOP + PIECE_TYPE_NB * attacker];
+    Bitboard queens = board->bitboards[PIECE_QUEEN + PIECE_TYPE_NB * attacker];
+    Bitboard sliders = bishops | queens;
+    for (Bitboard bb = sliders; bb; bb &= bb - 1ULL) {
+        Square sq = bits_ls1b(bb);
+        if (attacks_bishop(sq, occ) & (1ULL << square)) {
+            return 1;
+        }
+    }
+
+    Bitboard rooks = board->bitboards[PIECE_ROOK + PIECE_TYPE_NB * attacker];
+    sliders = rooks | queens;
+    for (Bitboard bb = sliders; bb; bb &= bb - 1ULL) {
+        Square sq = bits_ls1b(bb);
+        if (attacks_rook(sq, occ) & (1ULL << square)) {
+            return 1;
+        }
+    }
+
+    Bitboard pawns = board->bitboards[PIECE_PAWN + PIECE_TYPE_NB * attacker];
+    for (Bitboard bb = pawns; bb; bb &= bb - 1ULL) {
+        Square sq = bits_ls1b(bb);
+        if (attacks_pawn(sq, attacker) & (1ULL << square)) {
+            return 1;
+        }
+    }
+
+    Bitboard king = board->bitboards[PIECE_KING + PIECE_TYPE_NB * attacker];
+    if (king) {
+        Square sq = bits_ls1b(king);
+        if (attacks_king(sq) & (1ULL << square)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+void board_make_move(Board* board, const Move* move) {
+    if (board == NULL || move == NULL) {
+        return;
+    }
+
+    Piece piece = move->piece;
+    enum Color color = board->side_to_move;
+    Bitboard from_bb = 1ULL << move->from;
+    Bitboard to_bb = 1ULL << move->to;
+
+    board->bitboards[piece + PIECE_TYPE_NB * color] &= ~from_bb;
+    board->bitboards[piece + PIECE_TYPE_NB * color] |= to_bb;
+    board->squares[move->from] = PIECE_NONE;
+    board->squares[move->to] = piece;
+    board->side_to_move = (color == COLOR_WHITE) ? COLOR_BLACK : COLOR_WHITE;
+}
+
+void board_unmake_move(Board* board, const Move* move) {
+    if (board == NULL || move == NULL) {
+        return;
+    }
+
+    enum Color color = (board->side_to_move == COLOR_WHITE) ? COLOR_BLACK : COLOR_WHITE;
+    Piece piece = move->piece;
+    Bitboard from_bb = 1ULL << move->from;
+    Bitboard to_bb = 1ULL << move->to;
+
+    board->bitboards[piece + PIECE_TYPE_NB * color] |= from_bb;
+    board->bitboards[piece + PIECE_TYPE_NB * color] &= ~to_bb;
+    board->squares[move->from] = piece;
+    board->squares[move->to] = move->capture;
+    board->side_to_move = color;
+}
+

--- a/src/board.h
+++ b/src/board.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "attacks.h"
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void board_init(Board* board);
+void board_set_start_position(Board* board);
+Bitboard board_occupancy(const Board* board, enum Color color);
+int board_is_square_attacked(const Board* board, Square square, enum Color attacker);
+void board_make_move(Board* board, const Move* move);
+void board_unmake_move(Board* board, const Move* move);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/eval.c
+++ b/src/eval.c
@@ -1,0 +1,33 @@
+#include "eval.h"
+#include "board.h"
+#include "bits.h"
+
+Value eval_position(const Board* board) {
+    if (board == NULL) {
+        return VALUE_DRAW;
+    }
+
+    Value material = 0;
+    static const Value piece_values[PIECE_TYPE_NB] = {
+        0, 100, 320, 330, 500, 900, 20000
+    };
+
+    for (int color = COLOR_WHITE; color < COLOR_NB; ++color) {
+        Value color_sum = 0;
+        for (int pt = PIECE_PAWN; pt < PIECE_TYPE_NB; ++pt) {
+            Bitboard bb = board->bitboards[pt + PIECE_TYPE_NB * color];
+            color_sum += piece_values[pt] * bits_popcount(bb);
+        }
+        if (color == COLOR_WHITE) {
+            material += color_sum;
+        } else {
+            material -= color_sum;
+        }
+    }
+
+    if (board->side_to_move == COLOR_WHITE) {
+        return material;
+    }
+    return -material;
+}
+

--- a/src/eval.h
+++ b/src/eval.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Value eval_position(const Board* board);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/history.c
+++ b/src/history.c
@@ -1,0 +1,29 @@
+#include "history.h"
+
+#include "util.h"
+
+void history_init(HistoryTable* history) {
+    if (history == NULL) {
+        return;
+    }
+    util_zero_memory(history, sizeof(*history));
+}
+
+void history_update(HistoryTable* history, const Move* move, int bonus) {
+    if (history == NULL || move == NULL) {
+        return;
+    }
+    enum Color color = (bonus >= 0) ? COLOR_WHITE : COLOR_BLACK;
+    int value = history->history[color][move->piece][move->to];
+    value += bonus;
+    history->history[color][move->piece][move->to] = value;
+}
+
+int history_get(const HistoryTable* history, const Move* move) {
+    if (history == NULL || move == NULL) {
+        return 0;
+    }
+    enum Color color = COLOR_WHITE;
+    return history->history[color][move->piece][move->to];
+}
+

--- a/src/history.h
+++ b/src/history.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void history_init(HistoryTable* history);
+void history_update(HistoryTable* history, const Move* move, int bonus);
+int history_get(const HistoryTable* history, const Move* move);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/incbin.h
+++ b/src/incbin.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define INCBIN(NAME, FILENAME)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/makefile
+++ b/src/makefile
@@ -1,0 +1,34 @@
+CC ?= gcc
+CFLAGS ?= -O2 -std=c11
+SRCS = \
+    attacks.c \
+    bench.c \
+    berserk.c \
+    bits.c \
+    board.c \
+    eval.c \
+    history.c \
+    move.c \
+    movegen.c \
+    movepick.c \
+    perft.c \
+    random.c \
+    search.c \
+    see.c \
+    tb.c \
+    thread.c \
+    transposition.c \
+    uci.c \
+    util.c \
+    zobrist.c
+
+OBJS = $(SRCS:.c=.o)
+
+sirio: $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS)
+
+clean:
+	rm -f $(OBJS) sirio
+
+.PHONY: clean
+

--- a/src/move.c
+++ b/src/move.c
@@ -1,0 +1,20 @@
+#include "move.h"
+
+Move move_create(Square from, Square to, Piece piece, Piece capture, Piece promotion, int flags) {
+    Move move;
+    move.from = from;
+    move.to = to;
+    move.piece = piece;
+    move.capture = capture;
+    move.promotion = promotion;
+    move.flags = flags;
+    return move;
+}
+
+int move_is_null(const Move* move) {
+    if (move == NULL) {
+        return 1;
+    }
+    return move->from == move->to && move->piece == PIECE_NONE;
+}
+

--- a/src/move.h
+++ b/src/move.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Move move_create(Square from, Square to, Piece piece, Piece capture, Piece promotion, int flags);
+int move_is_null(const Move* move);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -1,0 +1,54 @@
+#include "movegen.h"
+#include "attacks.h"
+#include "bits.h"
+
+void movegen_generate_legal_moves(const Board* board, MoveList* list) {
+    if (board == NULL || list == NULL) {
+        return;
+    }
+
+    list->size = 0;
+
+    enum Color color = board->side_to_move;
+    Bitboard occupancy = board_occupancy(board, COLOR_WHITE) | board_occupancy(board, COLOR_BLACK);
+    Bitboard pieces = board_occupancy(board, color);
+
+    while (pieces) {
+        Bitboard lsb = bits_pop_lsb(&pieces);
+        Square from = bits_ls1b(lsb);
+        Piece piece = board->squares[from];
+        Bitboard attacks = 0ULL;
+
+        switch (piece) {
+            case PIECE_PAWN:
+                attacks = attacks_pawn(from, color);
+                break;
+            case PIECE_KNIGHT:
+                attacks = attacks_knight(from);
+                break;
+            case PIECE_BISHOP:
+                attacks = attacks_bishop(from, occupancy);
+                break;
+            case PIECE_ROOK:
+                attacks = attacks_rook(from, occupancy);
+                break;
+            case PIECE_QUEEN:
+                attacks = attacks_queen(from, occupancy);
+                break;
+            case PIECE_KING:
+                attacks = attacks_king(from);
+                break;
+            default:
+                break;
+        }
+
+        Bitboard targets = attacks & ~board_occupancy(board, color);
+        while (targets) {
+            Bitboard to_bb = bits_pop_lsb(&targets);
+            Square to = bits_ls1b(to_bb);
+            Move move = move_create(from, to, piece, board->squares[to], PIECE_NONE, 0);
+            list->moves[list->size++] = move;
+        }
+    }
+}
+

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "board.h"
+#include "move.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void movegen_generate_legal_moves(const Board* board, MoveList* list);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/movepick.c
+++ b/src/movepick.c
@@ -1,0 +1,29 @@
+#include "movepick.h"
+
+static int move_value(const Move* move) {
+    if (move == NULL) {
+        return 0;
+    }
+    return (move->capture != PIECE_NONE) ? 1 : 0;
+}
+
+void movepick_sort(MoveList* list) {
+    if (list == NULL) {
+        return;
+    }
+
+    for (size_t i = 0; i < list->size; ++i) {
+        size_t best = i;
+        for (size_t j = i + 1; j < list->size; ++j) {
+            if (move_value(&list->moves[j]) > move_value(&list->moves[best])) {
+                best = j;
+            }
+        }
+        if (best != i) {
+            Move tmp = list->moves[i];
+            list->moves[i] = list->moves[best];
+            list->moves[best] = tmp;
+        }
+    }
+}
+

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "movegen.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void movepick_sort(MoveList* list);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/perft.c
+++ b/src/perft.c
@@ -1,0 +1,26 @@
+#include "perft.h"
+#include "movegen.h"
+
+uint64_t perft_count(Board* board, int depth) {
+    if (board == NULL || depth <= 0) {
+        return 1ULL;
+    }
+
+    MoveList list;
+    movegen_generate_legal_moves(board, &list);
+
+    if (depth == 1) {
+        return (uint64_t)list.size;
+    }
+
+    uint64_t nodes = 0ULL;
+    for (size_t i = 0; i < list.size; ++i) {
+        Move move = list.moves[i];
+        board_make_move(board, &move);
+        nodes += perft_count(board, depth - 1);
+        board_unmake_move(board, &move);
+    }
+
+    return nodes;
+}
+

--- a/src/perft.h
+++ b/src/perft.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t perft_count(Board* board, int depth);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/random.c
+++ b/src/random.c
@@ -1,0 +1,23 @@
+#include "random.h"
+
+#include <stddef.h>
+
+void random_init(RandomState* state, uint64_t seed) {
+    if (state == NULL) {
+        return;
+    }
+    state->seed = seed ? seed : 0x9E3779B97F4A7C15ULL;
+}
+
+uint64_t random_next(RandomState* state) {
+    if (state == NULL) {
+        return 0ULL;
+    }
+    uint64_t x = state->seed;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    state->seed = x;
+    return x * 0x2545F4914F6CDD1DULL;
+}
+

--- a/src/random.h
+++ b/src/random.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct RandomState {
+    uint64_t seed;
+} RandomState;
+
+void random_init(RandomState* state, uint64_t seed);
+uint64_t random_next(RandomState* state);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/search.c
+++ b/src/search.c
@@ -1,0 +1,77 @@
+#include "search.h"
+
+#include "board.h"
+#include "move.h"
+#include "movepick.h"
+
+static Value search_alpha_beta(SearchContext* context, int depth, Value alpha, Value beta) {
+    if (depth <= 0) {
+        return eval_position(context->board);
+    }
+
+    MoveList moves;
+    movegen_generate_legal_moves(context->board, &moves);
+    if (moves.size == 0) {
+        return eval_position(context->board);
+    }
+
+    movepick_sort(&moves);
+
+    Value best = -VALUE_INFINITE;
+    for (size_t i = 0; i < moves.size; ++i) {
+        Move move = moves.moves[i];
+        board_make_move(context->board, &move);
+        Value score = -search_alpha_beta(context, depth - 1, -beta, -alpha);
+        board_unmake_move(context->board, &move);
+
+        if (score > best) {
+            best = score;
+        }
+        if (score > alpha) {
+            alpha = score;
+            context->best_move = move;
+            context->best_value = score;
+        }
+        if (alpha >= beta) {
+            break;
+        }
+    }
+
+    return best;
+}
+
+void search_init(SearchContext* context, Board* board, TranspositionTable* tt, HistoryTable* history) {
+    if (context == NULL) {
+        return;
+    }
+    context->board = board;
+    context->history = history;
+    context->best_value = VALUE_NONE;
+    context->best_move = move_create(0, 0, PIECE_NONE, PIECE_NONE, PIECE_NONE, 0);
+    (void)tt;
+}
+
+Move search_iterative_deepening(SearchContext* context, const SearchLimits* limits) {
+    if (context == NULL || limits == NULL) {
+        return move_create(0, 0, PIECE_NONE, PIECE_NONE, PIECE_NONE, 0);
+    }
+
+    Move best_move = move_create(0, 0, PIECE_NONE, PIECE_NONE, PIECE_NONE, 0);
+    for (int depth = 1; depth <= limits->depth; ++depth) {
+        Value value = search_root(context, depth);
+        if (!move_is_null(&context->best_move)) {
+            best_move = context->best_move;
+            context->best_value = value;
+        }
+    }
+
+    return best_move;
+}
+
+Value search_root(SearchContext* context, int depth) {
+    if (context == NULL) {
+        return VALUE_NONE;
+    }
+    return search_alpha_beta(context, depth, -VALUE_INFINITE, VALUE_INFINITE);
+}
+

--- a/src/search.h
+++ b/src/search.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "eval.h"
+#include "movegen.h"
+#include "transposition.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void search_init(SearchContext* context, Board* board, TranspositionTable* tt, HistoryTable* history);
+Move search_iterative_deepening(SearchContext* context, const SearchLimits* limits);
+Value search_root(SearchContext* context, int depth);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/see.c
+++ b/src/see.c
@@ -1,0 +1,12 @@
+#include "see.h"
+#include "attacks.h"
+
+Value see_evaluate(const Board* board, Square square) {
+    if (board == NULL || square < 0 || square >= 64) {
+        return VALUE_DRAW;
+    }
+
+    enum Color attacker = board->side_to_move;
+    return board_is_square_attacked(board, square, attacker) ? 100 : 0;
+}
+

--- a/src/see.h
+++ b/src/see.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+Value see_evaluate(const Board* board, Square square);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/tb.c
+++ b/src/tb.c
@@ -1,0 +1,10 @@
+#include "tb.h"
+
+void tb_init(void) {
+}
+
+Value tb_probe(const Board* board) {
+    (void)board;
+    return VALUE_NONE;
+}
+

--- a/src/tb.h
+++ b/src/tb.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void tb_init(void);
+Value tb_probe(const Board* board);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/thread.c
+++ b/src/thread.c
@@ -1,0 +1,26 @@
+#include "thread.h"
+
+#include "util.h"
+
+void thread_init(ThreadContext* thread, SearchContext* search, int id) {
+    if (thread == NULL) {
+        return;
+    }
+    thread->search = search;
+    thread->id = id;
+}
+
+void thread_start(ThreadContext* thread) {
+    if (thread == NULL || thread->search == NULL) {
+        return;
+    }
+    util_log("thread_start called (stub)");
+}
+
+void thread_join(ThreadContext* thread) {
+    if (thread == NULL) {
+        return;
+    }
+    util_log("thread_join called (stub)");
+}
+

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "search.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void thread_init(ThreadContext* thread, SearchContext* search, int id);
+void thread_start(ThreadContext* thread);
+void thread_join(ThreadContext* thread);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -1,0 +1,48 @@
+#include "transposition.h"
+
+#include <stdlib.h>
+
+#include "util.h"
+
+void transposition_init(TranspositionTable* table, size_t size) {
+    if (table == NULL || size == 0) {
+        return;
+    }
+    table->size = size;
+    table->entries = (TranspositionEntry*)calloc(size, sizeof(TranspositionEntry));
+}
+
+void transposition_free(TranspositionTable* table) {
+    if (table == NULL) {
+        return;
+    }
+    free(table->entries);
+    table->entries = NULL;
+    table->size = 0;
+}
+
+void transposition_store(TranspositionTable* table, uint64_t key, Value value, Move move, int depth, int flags) {
+    if (table == NULL || table->entries == NULL || table->size == 0) {
+        return;
+    }
+    size_t index = key % table->size;
+    TranspositionEntry* entry = &table->entries[index];
+    entry->key = key;
+    entry->value = value;
+    entry->best_move = move;
+    entry->depth = depth;
+    entry->flags = flags;
+}
+
+const TranspositionEntry* transposition_probe(const TranspositionTable* table, uint64_t key) {
+    if (table == NULL || table->entries == NULL || table->size == 0) {
+        return NULL;
+    }
+    size_t index = key % table->size;
+    const TranspositionEntry* entry = &table->entries[index];
+    if (entry->key == key) {
+        return entry;
+    }
+    return NULL;
+}
+

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void transposition_init(TranspositionTable* table, size_t size);
+void transposition_free(TranspositionTable* table);
+void transposition_store(TranspositionTable* table, uint64_t key, Value value, Move move, int depth, int flags);
+const TranspositionEntry* transposition_probe(const TranspositionTable* table, uint64_t key);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint64_t Bitboard;
+typedef uint32_t MoveKey;
+typedef int Square;
+typedef int Piece;
+typedef int Value;
+
+enum Color {
+    COLOR_WHITE = 0,
+    COLOR_BLACK = 1,
+    COLOR_NB
+};
+
+enum PieceType {
+    PIECE_NONE = 0,
+    PIECE_PAWN,
+    PIECE_KNIGHT,
+    PIECE_BISHOP,
+    PIECE_ROOK,
+    PIECE_QUEEN,
+    PIECE_KING,
+    PIECE_TYPE_NB
+};
+
+typedef struct Move {
+    Square from;
+    Square to;
+    Piece piece;
+    Piece capture;
+    Piece promotion;
+    int flags;
+} Move;
+
+typedef struct MoveList {
+    Move moves[256];
+    size_t size;
+} MoveList;
+
+typedef struct Board {
+    Piece squares[64];
+    Bitboard bitboards[PIECE_TYPE_NB * COLOR_NB];
+    enum Color side_to_move;
+    int castling_rights;
+    Square en_passant_square;
+    int halfmove_clock;
+    int fullmove_number;
+} Board;
+
+typedef struct HistoryTable {
+    int32_t history[COLOR_NB][PIECE_TYPE_NB][64];
+} HistoryTable;
+
+typedef struct SearchLimits {
+    int depth;
+    int movetime_ms;
+    int nodes;
+    int infinite;
+} SearchLimits;
+
+typedef struct SearchContext {
+    Board* board;
+    HistoryTable* history;
+    SearchLimits limits;
+    Value best_value;
+    Move best_move;
+} SearchContext;
+
+typedef struct ThreadContext {
+    SearchContext* search;
+    int id;
+} ThreadContext;
+
+typedef struct TranspositionEntry {
+    uint64_t key;
+    Value value;
+    Move best_move;
+    int depth;
+    int flags;
+} TranspositionEntry;
+
+typedef struct TranspositionTable {
+    TranspositionEntry* entries;
+    size_t size;
+} TranspositionTable;
+
+#define VALUE_MATE 32000
+#define VALUE_INFINITE 31000
+#define VALUE_DRAW 0
+#define VALUE_NONE 29000
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/uci.c
+++ b/src/uci.c
@@ -1,0 +1,30 @@
+#include "uci.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "board.h"
+#include "movegen.h"
+
+void uci_loop(SearchContext* context) {
+    char line[1024];
+    while (fgets(line, sizeof(line), stdin)) {
+        if (strncmp(line, "uci", 3) == 0) {
+            printf("id name SirioC\n");
+            printf("id author OpenAI\n");
+            printf("uciok\n");
+        } else if (strncmp(line, "isready", 7) == 0) {
+            printf("readyok\n");
+        } else if (strncmp(line, "position startpos", 18) == 0) {
+            board_set_start_position(context->board);
+        } else if (strncmp(line, "go", 2) == 0) {
+            SearchLimits limits = { .depth = 1, .movetime_ms = 0, .nodes = 0, .infinite = 0 };
+            Move best = search_iterative_deepening(context, &limits);
+            printf("bestmove %d%d\n", best.from, best.to);
+        } else if (strncmp(line, "quit", 4) == 0) {
+            break;
+        }
+        fflush(stdout);
+    }
+}
+

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "search.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void uci_loop(SearchContext* context);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,38 @@
+#include "util.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+void util_zero_memory(void* ptr, size_t size) {
+    if (ptr == NULL || size == 0) {
+        return;
+    }
+    memset(ptr, 0, size);
+}
+
+void util_copy_memory(void* dst, const void* src, size_t size) {
+    if (dst == NULL || src == NULL || size == 0) {
+        return;
+    }
+    memcpy(dst, src, size);
+}
+
+void util_log(const char* message) {
+    if (message == NULL) {
+        return;
+    }
+    fprintf(stderr, "%s\n", message);
+}
+
+void util_snprintf(char* buffer, size_t size, const char* fmt, ...) {
+    if (buffer == NULL || size == 0 || fmt == NULL) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buffer, size, fmt, args);
+    va_end(args);
+}
+

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void util_zero_memory(void* ptr, size_t size);
+void util_copy_memory(void* dst, const void* src, size_t size);
+void util_log(const char* message);
+void util_snprintf(char* buffer, size_t size, const char* fmt, ...);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+

--- a/src/zobrist.c
+++ b/src/zobrist.c
@@ -1,0 +1,44 @@
+#include "zobrist.h"
+
+#include "board.h"
+#include "random.h"
+
+static uint64_t g_piece_keys[COLOR_NB][PIECE_TYPE_NB][64];
+static uint64_t g_side_key;
+
+void zobrist_init(void) {
+    RandomState state;
+    random_init(&state, 0xC0FFEEULL);
+
+    for (int color = 0; color < COLOR_NB; ++color) {
+        for (int piece = 0; piece < PIECE_TYPE_NB; ++piece) {
+            for (int square = 0; square < 64; ++square) {
+                g_piece_keys[color][piece][square] = random_next(&state);
+            }
+        }
+    }
+    g_side_key = random_next(&state);
+}
+
+uint64_t zobrist_key(const Board* board) {
+    if (board == NULL) {
+        return 0ULL;
+    }
+
+    uint64_t key = 0ULL;
+    for (int square = 0; square < 64; ++square) {
+        Piece piece = board->squares[square];
+        if (piece == PIECE_NONE) {
+            continue;
+        }
+        enum Color color = (board->bitboards[piece + PIECE_TYPE_NB * COLOR_WHITE] & (1ULL << square)) ? COLOR_WHITE : COLOR_BLACK;
+        key ^= g_piece_keys[color][piece][square];
+    }
+
+    if (board->side_to_move == COLOR_BLACK) {
+        key ^= g_side_key;
+    }
+
+    return key;
+}
+

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void zobrist_init(void);
+uint64_t zobrist_key(const Board* board);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+


### PR DESCRIPTION
## Summary
- add initial source and header files for the chess engine including attacks, board handling, move generation, search, and utilities
- provide placeholder implementations for evaluation, transposition, threading, tablebase, and zobrist hashing infrastructure
- add a simple makefile and benchmarking/uci stubs to support future development and compilation workflows

## Testing
- make -C src sirio *(fails: no main entry point yet)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1dba536c8327a5c01d62b67b804d