### PR TITLE
Add main entry point to UCI module

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -4,7 +4,10 @@
 #include <string.h>
 
 #include "board.h"
+#include "history.h"
 #include "movegen.h"
+#include "search.h"
+#include "transposition.h"
 
 void uci_loop(SearchContext* context) {
     char line[1024];
@@ -26,5 +29,23 @@ void uci_loop(SearchContext* context) {
         }
         fflush(stdout);
     }
+}
+
+int main(void) {
+    Board board;
+    HistoryTable history;
+    TranspositionTable tt;
+    SearchContext context;
+
+    board_init(&board);
+    history_init(&history);
+    transposition_init(&tt, 1 << 16);
+    search_init(&context, &board, &tt, &history);
+    board_set_start_position(&board);
+
+    uci_loop(&context);
+
+    transposition_free(&tt);
+    return 0;
 }
 


### PR DESCRIPTION
## Summary
- include the search, history, and transposition headers in `uci.c`
- add a minimal `main` function that initializes engine state and starts the UCI loop

## Testing
- `cd src && CC=clang make`


------
https://chatgpt.com/codex/tasks/task_e_68dc25f004d08327b46df55e791915c9