### PR TITLE
Integrate neural evaluation and enable SSE4.1 build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ target_compile_options(sirio_core PRIVATE
     $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
     $<$<CXX_COMPILER_ID:MSVC>:/W4 /permissive->)
 
+if (CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(sirio_core PUBLIC -msse4.1 -mpopcnt)
+elseif (MSVC)
+    target_compile_options(sirio_core PUBLIC /arch:AVX)
+endif()
+
 add_executable(sirioc src/pyrrhic/main.cpp)
 target_link_libraries(sirioc PRIVATE sirio_core)
 

--- a/src/eval.c
+++ b/src/eval.c
@@ -1,33 +1,62 @@
 #include "eval.h"
 #include "board.h"
 #include "bits.h"
+#include "nn/accumulator.h"
+#include "nn/evaluate.h"
+
+#include <stdbool.h>
+
+static sirio_nn_model g_eval_model;
+static bool g_eval_model_ready = false;
+
+static void eval_ensure_initialized(void) {
+    if (g_eval_model_ready) {
+        return;
+    }
+
+    sirio_nn_model_init(&g_eval_model);
+    g_eval_model_ready = true;
+}
+
+void eval_init(void) {
+    eval_ensure_initialized();
+}
+
+int eval_load_network(const char* path) {
+    eval_ensure_initialized();
+    return sirio_nn_model_load(&g_eval_model, path);
+}
 
 Value eval_position(const Board* board) {
     if (board == NULL) {
         return VALUE_DRAW;
     }
 
-    Value material = 0;
-    static const Value piece_values[PIECE_TYPE_NB] = {
-        0, 100, 320, 330, 500, 900, 20000
-    };
+    eval_ensure_initialized();
+
+    sirio_accumulator accumulator;
+    sirio_accumulator_reset(&accumulator);
 
     for (int color = COLOR_WHITE; color < COLOR_NB; ++color) {
-        Value color_sum = 0;
+        const sirio_nn_color nn_color =
+            (color == COLOR_WHITE) ? SIRIO_NN_COLOR_WHITE : SIRIO_NN_COLOR_BLACK;
+
         for (int pt = PIECE_PAWN; pt < PIECE_TYPE_NB; ++pt) {
-            Bitboard bb = board->bitboards[pt + PIECE_TYPE_NB * color];
-            color_sum += piece_values[pt] * bits_popcount(bb);
-        }
-        if (color == COLOR_WHITE) {
-            material += color_sum;
-        } else {
-            material -= color_sum;
+            const Bitboard bb = board->bitboards[pt + PIECE_TYPE_NB * color];
+            const int count = bits_popcount(bb);
+            if (count == 0) {
+                continue;
+            }
+
+            const int nn_index = pt - PIECE_PAWN;
+            sirio_accumulator_add(&accumulator, nn_color, nn_index, count);
         }
     }
 
-    if (board->side_to_move == COLOR_WHITE) {
-        return material;
+    int score = sirio_nn_evaluate(&g_eval_model, &accumulator);
+    if (board->side_to_move == COLOR_BLACK) {
+        score = -score;
     }
-    return -material;
+    return score;
 }
 

--- a/src/eval.h
+++ b/src/eval.h
@@ -6,6 +6,8 @@
 extern "C" {
 #endif
 
+void eval_init(void);
+int eval_load_network(const char* path);
 Value eval_position(const Board* board);
 
 #ifdef __cplusplus

--- a/src/uci.c
+++ b/src/uci.c
@@ -8,6 +8,7 @@
 #include "movegen.h"
 #include "search.h"
 #include "transposition.h"
+#include "eval.h"
 
 void uci_loop(SearchContext* context) {
     char line[1024];
@@ -38,6 +39,10 @@ int main(void) {
     SearchContext context;
 
     board_init(&board);
+    eval_init();
+    if (!eval_load_network("resources/network.dat")) {
+        fprintf(stderr, "warning: could not load network weights from resources/network.dat, using defaults\n");
+    }
     history_init(&history);
     transposition_init(&tt, 1 << 16);
     search_init(&context, &board, &tt, &history);


### PR DESCRIPTION
## Summary
- add SSE4.1 + POPCNT (or AVX on MSVC) compile flags to the core target so optimized instructions are enabled by default
- replace the material-only evaluator with the neural accumulator backend and expose initialization + network loading helpers
- load the default network weights during UCI startup with a warning fallback when the file is missing

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68dc2782a78483279ee879998e584a8e