### PR TITLE
Rename Berserk artifacts and update UCI metadata

### DIFF
--- a/src/SirioC.c
+++ b/src/SirioC.c
@@ -1,0 +1,7 @@
+#include "SirioC.h"
+
+int sirio_run(SearchContext* context) {
+    bench_run(context);
+    return 0;
+}
+

--- a/src/SirioC.h
+++ b/src/SirioC.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-int berserk_run(SearchContext* context);
+int sirio_run(SearchContext* context);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/berserk.c
+++ b/src/berserk.c
@@ -1,7 +1,0 @@
-#include "berserk.h"
-
-int berserk_run(SearchContext* context) {
-    bench_run(context);
-    return 0;
-}
-

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@ CFLAGS ?= -O2 -std=c11
 SRCS = \
     attacks.c \
     bench.c \
-    berserk.c \
+    SirioC.c \
     bits.c \
     board.c \
     eval.c \
@@ -26,17 +26,17 @@ SRCS = \
 
 OBJS = $(SRCS:.c=.o)
 
-sirio: $(OBJS)
+SirioC-0.1.0: $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $(OBJS)
 
-bench: sirio
-	@printf "uci\nisready\nucinewgame\nposition startpos\ngo depth 1\nquit\n" | ./sirio --uci > .sirio_bench.log
+bench: SirioC-0.1.0
+	@printf "uci\nisready\nucinewgame\nposition startpos\ngo depth 1\nquit\n" | ./SirioC-0.1.0 --uci > .sirio_bench.log
 	@cat .sirio_bench.log
 	@awk '/^bestmove/ { bm=$$2 } END { if (bm == "" || bm == "0000" || bm == "(none)") { printf("bench: invalid bestmove %s\n", bm); exit 1 } }' .sirio_bench.log
 	@rm -f .sirio_bench.log
 
 clean:
-	rm -f $(OBJS) sirio
+	rm -f $(OBJS) SirioC-0.1.0
 
 .PHONY: clean bench
 

--- a/src/pyrrhic/engine.cpp
+++ b/src/pyrrhic/engine.cpp
@@ -24,8 +24,8 @@ std::string trim(std::string value) {
     return value;
 }
 
-constexpr const char* kEngineIdName = "SirioC-0.1.0";
-constexpr const char* kEngineIdAuthor = "SirioC Team";
+constexpr const char* kEngineIdName = "SirioC-0.1.0 300925";
+constexpr const char* kEngineIdAuthor = "Jorge Ruiz and Codex Chatgpt creditos";
 
 }  // namespace
 
@@ -124,7 +124,6 @@ bool Engine::configure_tablebase(const std::string& path) {
 }
 
 void Engine::run_cli(std::istream& input, std::ostream& output) {
-    output << "SirioC interactive shell. Type 'help' for a list of commands." << std::endl;
     std::string line;
 
     while (std::getline(input, line)) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -192,8 +192,8 @@ static void uci_loop_impl(UciState* state) {
     char line[1024];
     while (fgets(line, sizeof(line), stdin)) {
         if (strncmp(line, "uci", 3) == 0 && (line[3] == '\0' || isspace((unsigned char)line[3]))) {
-            printf("id name SirioC\n");
-            printf("id author OpenAI\n");
+            printf("id name SirioC-0.1.0 300925\n");
+            printf("id author Jorge Ruiz and Codex Chatgpt creditos\n");
             print_options(state);
             printf("uciok\n");
         } else if (strncmp(line, "isready", 7) == 0 && (line[7] == '\0' || isspace((unsigned char)line[7]))) {


### PR DESCRIPTION
## Summary
- rename the Berserk source/header to SirioC equivalents and adjust the make build to emit the SirioC-0.1.0 executable
- update UCI identification strings and remove the interactive shell banner to match the requested branding

## Testing
- `make -C src`


------
https://chatgpt.com/codex/tasks/task_e_68dc47b49c008327817eb9aeb16998bd