### PR TITLE
Fix enum arithmetic warning in board bitboards array

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -46,7 +46,7 @@ typedef struct MoveList {
 
 typedef struct Board {
     Piece squares[64];
-    Bitboard bitboards[PIECE_TYPE_NB * COLOR_NB];
+    Bitboard bitboards[((size_t)PIECE_TYPE_NB) * ((size_t)COLOR_NB)];
     enum Color side_to_move;
     int castling_rights;
     Square en_passant_square;


### PR DESCRIPTION
## Summary
- adjust the Board bitboards array size expression to use size_t conversions
- eliminate the Clang deprecated enum arithmetic warning when building

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68dc52bd537c8327898667ed2ba3eaa4