### PR TITLE
Improve time management and MultiPV reporting

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -7,7 +7,17 @@ void bench_run(SearchContext* context) {
         return;
     }
 
-    SearchLimits limits = { .depth = 1, .movetime_ms = 0, .nodes = 0, .infinite = 0, .multipv = 1 };
+    SearchLimits limits = { .depth = 4,
+                            .movetime_ms = 0,
+                            .nodes = 0,
+                            .infinite = 0,
+                            .multipv = 1,
+                            .wtime_ms = 0,
+                            .btime_ms = 0,
+                            .winc_ms = 0,
+                            .binc_ms = 0,
+                            .moves_to_go = 0,
+                            .ponder = 0 };
     Move move = search_iterative_deepening(context, &limits);
     printf("bench bestmove %d%d value %d\n", move.from, move.to, context->best_value);
 }

--- a/src/search.h
+++ b/src/search.h
@@ -10,7 +10,7 @@ extern "C" {
 
 void search_init(SearchContext* context, Board* board, TranspositionTable* tt, HistoryTable* history);
 Move search_iterative_deepening(SearchContext* context, const SearchLimits* limits);
-Value search_root(SearchContext* context, int depth);
+Value search_root(SearchContext* context, int depth, Value alpha, Value beta);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/types.h
+++ b/src/types.h
@@ -64,6 +64,12 @@ typedef struct SearchLimits {
     int nodes;
     int infinite;
     int multipv;
+    int wtime_ms;
+    int btime_ms;
+    int winc_ms;
+    int binc_ms;
+    int moves_to_go;
+    int ponder;
 } SearchLimits;
 
 typedef struct SearchContext {
@@ -79,6 +85,9 @@ typedef struct SearchContext {
     uint64_t start_time_ms;
     int stop;
     int move_overhead;
+    uint64_t nodes;
+    int depth_completed;
+    uint64_t last_search_time_ms;
 } SearchContext;
 
 typedef struct ThreadContext {


### PR DESCRIPTION
## Summary
- expand search limits and iterative deepening to track nodes, depth, and aspiration-based multipv ordering
- add UCI go parsing for time controls, cooperative stop handling, and info reporting with nps
- update bench defaults to exercise deeper searches with the extended limits

## Testing
- make -C src SirioC-0.1.0

------
https://chatgpt.com/codex/tasks/task_e_68dc537337348327a80c80c1e37bc408