### PR TITLE
Improve NNUE option handling and loading

### DIFF
--- a/src/nn/nnue.cpp
+++ b/src/nn/nnue.cpp
@@ -39,7 +39,11 @@ bool load_from_memory(const void* data, std::size_t size, const std::string& sou
     if (!data || size == 0) {
         return false;
     }
-    MemoryResource resource{static_cast<const std::uint8_t*>(data), size, source};
+    MemoryResource resource{
+        static_cast<const std::uint8_t*>(data),
+        size,
+        source,
+        Metadata::SourceType::Memory};
     Metadata meta;
     if (!loader::load_from_memory(resource, meta)) {
         return false;

--- a/src/nn/nnue_loader.h
+++ b/src/nn/nnue_loader.h
@@ -7,6 +7,8 @@
 namespace nnue {
 
 struct Metadata {
+    enum class SourceType { Unknown, File, Embedded, Memory };
+
     std::string architecture;
     std::string dimensions;
     std::string source;
@@ -14,12 +16,14 @@ struct Metadata {
     std::uint32_t feature_count = 0;
     std::uint32_t hidden_size = 0;
     std::uint32_t output_scale = 0;
+    SourceType source_type = SourceType::Unknown;
 };
 
 struct MemoryResource {
     const std::uint8_t* data = nullptr;
     std::size_t size = 0;
     std::string source;
+    Metadata::SourceType source_type = Metadata::SourceType::Memory;
 };
 
 namespace loader {

--- a/src/uci/Uci.h
+++ b/src/uci/Uci.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <filesystem>
+
+extern std::filesystem::path g_engine_dir;
+
 namespace uci {
 void loop();
 }


### PR DESCRIPTION
## Summary
- initialize options once at startup, track the engine directory, and resolve NNUE files relative to the executable with clearer logging in the UCI loop
- relax NNUE metadata validation so external networks load successfully while retaining source diagnostics
- detect the executable path in main so option defaults and NNUE loading work regardless of the caller's working directory

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68dc5ec351e083279591e0b0e1f0012b