### PR TITLE
Fix NN accumulator include usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,10 @@ add_library(sirio_core
     src/uci/Options.cpp
     src/uci/Uci.cpp)
 
-target_include_directories(sirio_core PUBLIC src)
+target_include_directories(sirio_core PUBLIC
+    src
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/nn
+)
 
 target_compile_features(sirio_core PUBLIC cxx_std_20)
 

--- a/src/nn/accumulator.c
+++ b/src/nn/accumulator.c
@@ -1,4 +1,4 @@
-#include "accumulator.h"
+#include "nn/accumulator.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/src/nn/evaluate.c
+++ b/src/nn/evaluate.c
@@ -1,5 +1,5 @@
 #include "evaluate.h"
-#include "accumulator.h"
+#include "nn/accumulator.h"
 #include "../board.h"
 
 #include <stdint.h>

--- a/src/nn/evaluate.h
+++ b/src/nn/evaluate.h
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "accumulator.h"
+#include "nn/accumulator.h"
 
 struct Board;
 


### PR DESCRIPTION
## Summary
- add the nn directory to sirio_core's public include paths
- use nn/accumulator.h in nn sources to align with existing include root

## Testing
- ⚠️ `cmake -S . -B build-clang -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++` *(fails: clang is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6b8b217c832793de39f02f53af2c