### PR TITLE
Trim whitespace in NNUE option values

### DIFF
--- a/src/uci/Options.cpp
+++ b/src/uci/Options.cpp
@@ -32,6 +32,15 @@ void Options::set(const std::string& name, const std::string& value) {
                  sanitized.back() == '>') {
         sanitized = sanitized.substr(1, sanitized.size() - 2);
       }
+
+      const auto first = sanitized.find_first_not_of(" \t\r\n\f\v");
+      if (first == std::string::npos) {
+        sanitized.clear();
+      } else {
+        const auto last = sanitized.find_last_not_of(" \t\r\n\f\v");
+        sanitized = sanitized.substr(first, last - first + 1);
+      }
+
       o.s = std::move(sanitized);
       break;
     }

--- a/test/engine_tests.cpp
+++ b/test/engine_tests.cpp
@@ -62,6 +62,10 @@ int main() {
     expect(OptionsMap.at("EvalFile").s == "sirio_default.nnue",
            "EvalFile should strip angle brackets");
 
+    OptionsMap.set("EvalFile", "<  sirio_default.nnue >");
+    expect(OptionsMap.at("EvalFile").s == "sirio_default.nnue",
+           "EvalFile should trim whitespace around values");
+
     const auto resolved = uci::resolve_nnue_path_for_tests(OptionsMap.at("EvalFile").s);
     expect(resolved == nnue_file,
            "EvalFile should resolve to the NNUE file in the engine directory");


### PR DESCRIPTION
## Summary
- trim whitespace around string option values to avoid leading/trailing spaces in EvalFile settings
- extend engine tests to cover the new sanitization behaviour

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build
- ./build/sirio_tests

------
https://chatgpt.com/codex/tasks/task_e_68dc72f072f08327be398841011d2716