### PR TITLE
Fix bench build and go defaults

### DIFF
--- a/src/nn/accumulator.c
+++ b/src/nn/accumulator.c
@@ -1,4 +1,4 @@
-#include "nn/accumulator.h"
+#include "accumulator.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/src/nn/evaluate.c
+++ b/src/nn/evaluate.c
@@ -1,5 +1,5 @@
 #include "evaluate.h"
-#include "nn/accumulator.h"
+#include "accumulator.h"
 #include "../board.h"
 
 #include <stdint.h>

--- a/src/nn/evaluate.h
+++ b/src/nn/evaluate.h
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "nn/accumulator.h"
+#include "accumulator.h"
 
 struct Board;
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -344,6 +344,11 @@ static void handle_go(UciState* state, char* args) {
         }
     }
 
+    if (limits.depth <= 0 && limits.movetime_ms <= 0 && limits.nodes <= 0 && !limits.infinite &&
+        limits.wtime_ms <= 0 && limits.btime_ms <= 0) {
+        limits.depth = 1;
+    }
+
     if (!limits.infinite && limits.movetime_ms <= 0) {
         int moves_to_go = limits.moves_to_go > 0 ? limits.moves_to_go : 30;
         if (moves_to_go <= 0) {


### PR DESCRIPTION
## Summary
- fix NNUE source includes so the C makefile bench target compiles
- default to a shallow depth search when `go` is invoked without limits to prevent stalls

## Testing
- make -C src
- make -C src bench
- ./src/SirioC-0.1.0 --uci <<'EOF'
uci
isready
position startpos
go
quit
EOF

------
https://chatgpt.com/codex/tasks/task_e_68dc74ea7c2083278b43a8a391a9bda7