### PR TITLE
Implement threaded UCI search and bench command

### DIFF
--- a/resources/bench.fens
+++ b/resources/bench.fens
@@ -1,0 +1,9 @@
+# SirioC benchmark positions
+rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
+r3k2r/ppp2ppp/2n2n2/3qp3/3P4/2N1PN2/PPP2PPP/R3K2R w KQkq - 0 1
+4rrk1/pppb1ppp/2np1q2/3Np3/3P4/2N1P1P1/PPQ2PBP/2RR2K1 w - - 0 1
+rnbq1rk1/pp2ppbp/3p1np1/2p5/3P4/2N1PN2/PPQ1BPPP/R1B2RK1 w - - 0 1
+r4rk1/1bqn1ppp/p2bpn2/1p6/3P4/2NBPN2/PPQN1PPP/2R2RK1 w - - 0 1
+r2q1rk1/pb2bppp/1p2pn2/2pp4/3P4/1PN1PN2/PB2BPPP/2RQ1RK1 w - - 0 1
+r1bq1rk1/ppp1bppp/2np1n2/4p3/3P4/2N1PN2/PPP1BPPP/R1BQ1RK1 w - - 0 1
+r1bqk2r/pppp1ppp/2n2n2/2b1p3/4P3/2NP1N2/PPP2PPP/R1BQKB1R w KQkq - 0 1

--- a/src/SirioC.c
+++ b/src/SirioC.c
@@ -1,7 +1,7 @@
 #include "SirioC.h"
 
 int sirio_run(SearchContext* context) {
-    bench_run(context);
+    bench_run(context, NULL);
     return 0;
 }
 

--- a/src/bench.c
+++ b/src/bench.c
@@ -1,24 +1,143 @@
 #include "bench.h"
 
-#include <stdio.h>
+#include "board.h"
+#include "move.h"
 
-void bench_run(SearchContext* context) {
+#include <ctype.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void bench_trim(char* text) {
+    if (!text) {
+        return;
+    }
+
+    char* start = text;
+    while (*start && isspace((unsigned char)*start)) {
+        ++start;
+    }
+
+    char* end = start + strlen(start);
+    while (end > start && isspace((unsigned char)*(end - 1))) {
+        --end;
+    }
+    *end = '\0';
+
+    if (start != text) {
+        memmove(text, start, strlen(start) + 1);
+    }
+}
+
+void bench_run(SearchContext* context, const SearchLimits* limits) {
     if (context == NULL) {
         return;
     }
 
-    SearchLimits limits = { .depth = 4,
-                            .movetime_ms = 0,
-                            .nodes = 0,
-                            .infinite = 0,
-                            .multipv = 1,
-                            .wtime_ms = 0,
-                            .btime_ms = 0,
-                            .winc_ms = 0,
-                            .binc_ms = 0,
-                            .moves_to_go = 0,
-                            .ponder = 0 };
-    Move move = search_iterative_deepening(context, &limits);
-    printf("bench bestmove %d%d value %d\n", move.from, move.to, context->best_value);
+    SearchLimits bench_limits = { .depth = 12,
+                                  .movetime_ms = 0,
+                                  .nodes = 0,
+                                  .infinite = 0,
+                                  .multipv = 1,
+                                  .wtime_ms = 0,
+                                  .btime_ms = 0,
+                                  .winc_ms = 0,
+                                  .binc_ms = 0,
+                                  .moves_to_go = 0,
+                                  .ponder = 0 };
+
+    if (limits) {
+        bench_limits = *limits;
+    }
+
+    const char* paths[] = { "resources/bench.fens", "../resources/bench.fens" };
+    FILE* file = NULL;
+    for (size_t i = 0; i < sizeof(paths) / sizeof(paths[0]); ++i) {
+        file = fopen(paths[i], "r");
+        if (file) {
+            break;
+        }
+    }
+
+    if (!file) {
+        printf("info string Failed to open resources/bench.fens\n");
+        fflush(stdout);
+        return;
+    }
+
+    uint64_t total_nodes = 0;
+    uint64_t total_time = 0;
+    int positions = 0;
+
+    char line[512];
+    while (fgets(line, sizeof(line), file)) {
+        char* cursor = line;
+        while (*cursor && isspace((unsigned char)*cursor)) {
+            ++cursor;
+        }
+        if (*cursor == '\0' || *cursor == '#') {
+            continue;
+        }
+
+        char* newline = strpbrk(cursor, "\r\n");
+        if (newline) {
+            *newline = '\0';
+        }
+
+        bench_trim(cursor);
+        if (*cursor == '\0') {
+            continue;
+        }
+
+        if (!board_set_fen(context->board, cursor)) {
+            printf("info string Invalid FEN in bench file: %s\n", cursor);
+            fflush(stdout);
+            continue;
+        }
+
+        context->stop = 0;
+        Move best = search_iterative_deepening(context, &bench_limits);
+        total_nodes += context->nodes;
+        total_time += context->last_search_time_ms;
+        ++positions;
+
+        char move_buffer[16];
+        move_to_uci(&best, move_buffer, sizeof(move_buffer));
+        if (move_buffer[0] == '\0') {
+            snprintf(move_buffer, sizeof(move_buffer), "0000");
+        }
+
+        printf("bench position %d bestmove %s nodes %" PRIu64 " time %" PRIu64 "\n",
+               positions,
+               move_buffer,
+               context->nodes,
+               context->last_search_time_ms);
+        fflush(stdout);
+    }
+
+    fclose(file);
+
+    if (positions == 0) {
+        printf("bench summary positions 0 time 0 nodes 0 nps 0\n");
+        fflush(stdout);
+        board_set_start_position(context->board);
+        return;
+    }
+
+    if (total_time == 0) {
+        total_time = 1;
+    }
+
+    uint64_t nps = (total_nodes * 1000ULL) / total_time;
+
+    printf("bench summary positions %d time %" PRIu64 " nodes %" PRIu64 " nps %" PRIu64 "\n",
+           positions,
+           total_time,
+           total_nodes,
+           nps);
+    fflush(stdout);
+
+    board_set_start_position(context->board);
 }
 

--- a/src/bench.h
+++ b/src/bench.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-void bench_run(SearchContext* context);
+void bench_run(SearchContext* context, const SearchLimits* limits);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/board.h
+++ b/src/board.h
@@ -9,6 +9,7 @@ extern "C" {
 
 void board_init(Board* board);
 void board_set_start_position(Board* board);
+int board_set_fen(Board* board, const char* fen);
 Bitboard board_occupancy(const Board* board, enum Color color);
 int board_is_square_attacked(const Board* board, Square square, enum Color attacker);
 void board_make_move(Board* board, const Move* move);

--- a/src/makefile
+++ b/src/makefile
@@ -4,6 +4,8 @@ CFLAGS ?= -O2 -std=c11
 CXXFLAGS ?= -O2 -std=c++20
 CFLAGS += -I../vendor/fathom
 CXXFLAGS += -I../vendor/fathom
+CFLAGS += -pthread
+CXXFLAGS += -pthread
 
 SRCS = \
     attacks.c \

--- a/src/types.h
+++ b/src/types.h
@@ -92,6 +92,7 @@ typedef struct SearchContext {
     uint64_t nodes;
     int depth_completed;
     uint64_t last_search_time_ms;
+    uint64_t last_info_report_ms;
 } SearchContext;
 
 typedef struct ThreadContext {


### PR DESCRIPTION
## Summary
- run UCI searches on a dedicated thread with cooperative stop handling and periodic info reporting
- add a bench command that loads FENs from resources/bench.fens and summarizes total nodes, time, and NPS
- load arbitrary FEN positions for benchmarking and enable pthread support in the build

## Testing
- `make`
- `printf "uci\nisready\nbench depth 1\nquit\n" | ./src/SirioC-0.1.0 --uci`


------
https://chatgpt.com/codex/tasks/task_e_68de69633f6883279c49018d432cc6b9