### PR TITLE
Add bench command to UCI loop and update author attribution

### DIFF
--- a/src/pyrrhic/engine.cpp
+++ b/src/pyrrhic/engine.cpp
@@ -24,8 +24,8 @@ std::string trim(std::string value) {
     return value;
 }
 
-constexpr const char* kEngineIdName = "SirioC-0.1.0 300925";
-constexpr const char* kEngineIdAuthor = "Jorge Ruiz and Codex Chatgpt creditos";
+constexpr const char* kEngineIdName = "SirioC-0.1.0";
+constexpr const char* kEngineIdAuthor = "Jorge Ruiz credits Codex open IA";
 
 }  // namespace
 


### PR DESCRIPTION
## Summary
- add a bench command to the UCI loop that scans resources/bench.fens, runs searches, and reports per-position plus summary statistics
- flush critical UCI responses (including go) so controllers receive bestmoves immediately and report when bench movetime is unsupported
- update engine identification strings to credit Jorge Ruiz and Codex open IA in both UCI and CLI banners

## Testing
- cmake --build build
- ctest --test-dir build
- ./build/sirioc --uci <<'EOF'
uci
isready
go depth 1
bench
quit
EOF

------
https://chatgpt.com/codex/tasks/task_e_68de6f56e99083279fb9daf72ab6eab1