### PR TITLE
Improve NNUE file auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ CMake with `-DSIRIOC_EMBED_NNUE=ON` and ensure that
 `resources/sirio_default.nnue` exists at configure time. When no NNUE file is
 configured the engine falls back to its built-in material evaluator.
 
+The engine automatically searches for `sirio_default.nnue`/`sirio_small.nnue`
+next to the executable, in parent directories' `resources/` folders, and in any
+directory pointed to by the `SIRIOC_RESOURCE_DIR` environment variable. This
+allows packaged builds (for example from a `build/` tree) to pick up networks
+downloaded into the source tree without requiring manual `EvalFile` paths.
+
 ## Building
 
 The project uses CMake and requires a compiler with C++20 support.

--- a/test/engine_tests.cpp
+++ b/test/engine_tests.cpp
@@ -51,7 +51,10 @@ int main() {
         out << "nnue";
     }
 
-    g_engine_dir = temp_root;
+    const fs::path nested_dir = temp_root / "build" / "bin";
+    fs::create_directories(nested_dir);
+
+    g_engine_dir = nested_dir;
     init_options();
     expect(OptionsMap.contains("EvalFile"), "EvalFile option should be available");
 
@@ -75,9 +78,7 @@ int main() {
            "EvalFile should clear again when set to <empty>");
 
     g_engine_dir = original_engine_dir;
-    fs::remove(nnue_file);
-    fs::remove(resources_dir);
-    fs::remove(temp_root);
+    fs::remove_all(temp_root);
 
     std::cout << "All tests passed" << std::endl;
     return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary
- expand NNUE weight discovery to search parent resource directories and an optional SIRIOC_RESOURCE_DIR hint
- make the UCI option defaults follow the same resolution logic and document the behavior
- update the NNUE option smoke test to cover binaries placed inside nested build trees

## Testing
- cmake -S . -B build -DSIRIOC_BUILD_TESTS=ON
- cmake --build build --target sirio_tests
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68de7c675e6c8327813d37781e55b4d4