### PR TITLE
Ensure deterministic UCI option order

### DIFF
--- a/src/uci/Options.cpp
+++ b/src/uci/Options.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <string>
 #include <utility>
+#include <vector>
 
 Options OptionsMap;
 
@@ -46,5 +47,21 @@ void Options::set(const std::string& name, const std::string& value) {
     }
   }
   if (o.on_change) o.on_change();
+}
+
+void Options::printUci() const {
+  std::vector<std::string> keys;
+  keys.reserve(size());
+  for (const auto& entry : *this) {
+    keys.push_back(entry.first);
+  }
+  std::sort(keys.begin(), keys.end());
+
+  for (const auto& key : keys) {
+    const auto it = find(key);
+    if (it != end()) {
+      std::cout << it->second.uciDecl(key) << "\n";
+    }
+  }
 }
 

--- a/src/uci/Options.h
+++ b/src/uci/Options.h
@@ -29,11 +29,7 @@ struct Option {
 
 struct Options : public std::unordered_map<std::string, Option> {
   void set(const std::string& name, const std::string& value);
-  void printUci() const {
-    for (const auto& [k, v] : *this) {
-      std::cout << v.uciDecl(k) << "\n";
-    }
-  }
+  void printUci() const;
 };
 
 extern Options OptionsMap;


### PR DESCRIPTION
## Summary
- ensure UCI option listing is deterministic by sorting option names before printing
- move the `printUci` implementation into the source file and include the necessary headers

## Testing
- cmake --build build
- ./build/sirio_tests

------
https://chatgpt.com/codex/tasks/task_e_68de85b5b5b883279ffc0489a1fac0f9