### PR TITLE
Fix eval.c merge artifacts breaking build

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
- codex/fix-nnue-weights-loading-issues-3nn6d5
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(__APPLE__)
@@ -16,9 +15,6 @@
 #else
 #include <unistd.h>
 #endif
-=======
- main
-
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
@@ -72,7 +68,6 @@ static int load_from_directory(sirio_nn_model* model, const char* directory, con
     return sirio_nn_model_load(model, buffer);
 }
 
-codex/fix-nnue-weights-loading-issues-3nn6d5
 static int get_executable_directory(char* buffer, size_t size) {
     if (!buffer || size == 0) {
         return 0;
@@ -119,8 +114,6 @@ static int get_executable_directory(char* buffer, size_t size) {
 #endif
 }
 
-=======
- main
 static int try_load_default_locations(sirio_nn_model* model, const char* file_name) {
     if (!file_name || !*file_name) {
         return 0;
@@ -169,7 +162,6 @@ static int try_load_default_locations(sirio_nn_model* model, const char* file_na
         }
     }
 
- codex/fix-nnue-weights-loading-issues-3nn6d5
     char exe_dir[PATH_MAX];
     if (get_executable_directory(exe_dir, sizeof(exe_dir))) {
         if (load_from_directory(model, exe_dir, file_name)) {
@@ -191,8 +183,6 @@ static int try_load_default_locations(sirio_nn_model* model, const char* file_na
         }
     }
 
-=======
- main
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- remove leftover conflict markers and stray text from `src/eval.c`
- restore clean helper definitions so the evaluator builds correctly

## Testing
- ctest


------
https://chatgpt.com/codex/tasks/task_e_68de8a2296b88327b72ffd6721f1af44