### PR TITLE
Update default NNUE references

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ neural weights are absent, SirioC now falls back to the legacy
 loading an `.nnue` file is strongly recommended for best strength.
 
 A convenience script, `scripts/download_nnue.sh`, fetches the current
-Stockfish main network (`sirio_default.nnue`) and the compact "small" network
-(`sirio_small.nnue`) into `resources/`:
+Stockfish main network (`nn-1c0000000000.nnue`) and the compact "small" network
+(`nn-37f18f62d772.nnue`) into `resources/`:
 
 ```bash
 ./scripts/download_nnue.sh
@@ -81,10 +81,10 @@ When the small network is configured, SirioC automatically switches to it in
 positions with 12 or fewer pieces to improve accuracy in simplified endgames.
 If you prefer to bundle the default weights with release binaries, configure
 CMake with `-DSIRIOC_EMBED_NNUE=ON` and ensure that
-`resources/sirio_default.nnue` exists at configure time. When no NNUE file is
+`resources/nn-1c0000000000.nnue` exists at configure time. When no NNUE file is
 configured the engine falls back to its built-in material evaluator.
 
-The engine automatically searches for `sirio_default.nnue`/`sirio_small.nnue`
+The engine automatically searches for `nn-1c0000000000.nnue`/`nn-37f18f62d772.nnue`
 next to the executable, in parent directories' `resources/` folders, and in any
 directory pointed to by the `SIRIOC_RESOURCE_DIR` environment variable. This
 allows packaged builds (for example from a `build/` tree) to pick up networks

--- a/scripts/download_nnue.sh
+++ b/scripts/download_nnue.sh
@@ -30,8 +30,8 @@ TARGET_DIR="$ROOT_DIR/resources"
 FORCE_DOWNLOAD=0
 DOWNLOAD_PRIMARY=1
 DOWNLOAD_SMALL=1
-PRIMARY_URL="${SIRIO_NNUE_PRIMARY_URL:-https://tests.stockfishchess.org/api/nn/nn-62ef826d1a6d.nnue}"
-SMALL_URL="${SIRIO_NNUE_SMALL_URL:-https://tests.stockfishchess.org/api/nn/nn-5af11540bbfe.nnue}"
+PRIMARY_URL="${SIRIO_NNUE_PRIMARY_URL:-https://tests.stockfishchess.org/api/nn/nn-1c0000000000.nnue}"
+SMALL_URL="${SIRIO_NNUE_SMALL_URL:-https://tests.stockfishchess.org/api/nn/nn-37f18f62d772.nnue}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -97,8 +97,8 @@ if [[ $DOWNLOAD_PRIMARY -eq 0 && $DOWNLOAD_SMALL -eq 0 ]]; then
 fi
 
 mkdir -p "$TARGET_DIR"
-PRIMARY_DEST="$TARGET_DIR/sirio_default.nnue"
-SMALL_DEST="$TARGET_DIR/sirio_small.nnue"
+PRIMARY_DEST="$TARGET_DIR/nn-1c0000000000.nnue"
+SMALL_DEST="$TARGET_DIR/nn-37f18f62d772.nnue"
 
 cleanup() {
     [[ -n ${TMP_FILE:-} && -f $TMP_FILE ]] && rm -f "$TMP_FILE"

--- a/src/eval.c
+++ b/src/eval.c
@@ -19,12 +19,12 @@
 #define PATH_MAX 4096
 #endif
 
-#define SIRIO_DEFAULT_NETWORK "resources/sirio_default.nnue"
-#define SIRIO_DEFAULT_NETWORK_ALT "../resources/sirio_default.nnue"
-#define SIRIO_DEFAULT_SMALL_NETWORK "resources/sirio_small.nnue"
-#define SIRIO_DEFAULT_SMALL_NETWORK_ALT "../resources/sirio_small.nnue"
-#define SIRIO_DEFAULT_PRIMARY_NAME "sirio_default.nnue"
-#define SIRIO_DEFAULT_SMALL_NAME "sirio_small.nnue"
+#define SIRIO_DEFAULT_NETWORK "resources/nn-1c0000000000.nnue"
+#define SIRIO_DEFAULT_NETWORK_ALT "../resources/nn-1c0000000000.nnue"
+#define SIRIO_DEFAULT_SMALL_NETWORK "resources/nn-37f18f62d772.nnue"
+#define SIRIO_DEFAULT_SMALL_NETWORK_ALT "../resources/nn-37f18f62d772.nnue"
+#define SIRIO_DEFAULT_PRIMARY_NAME "nn-1c0000000000.nnue"
+#define SIRIO_DEFAULT_SMALL_NAME "nn-37f18f62d772.nnue"
 #define SIRIO_SMALL_NETWORK_THRESHOLD 12
 
 static sirio_nn_model g_eval_model;

--- a/src/uci.c
+++ b/src/uci.c
@@ -18,8 +18,8 @@
 #include "transposition.h"
 #include "tb.h"
 
-#define UCI_DEFAULT_EVAL_FILE "resources/sirio_default.nnue"
-#define UCI_DEFAULT_EVAL_FILE_SMALL "resources/sirio_small.nnue"
+#define UCI_DEFAULT_EVAL_FILE "resources/nn-1c0000000000.nnue"
+#define UCI_DEFAULT_EVAL_FILE_SMALL "resources/nn-37f18f62d772.nnue"
 
 typedef struct {
     SearchContext* context;

--- a/src/uci/Uci.cpp
+++ b/src/uci/Uci.cpp
@@ -32,8 +32,8 @@ std::filesystem::path g_engine_dir;
 namespace {
 constexpr const char* kStartPositionFen =
     "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
-constexpr const char* kDefaultEvalFile = "sirio_default.nnue";
-constexpr const char* kDefaultEvalFileSmall = "sirio_small.nnue";
+constexpr const char* kDefaultEvalFile = "nn-1c0000000000.nnue";
+constexpr const char* kDefaultEvalFileSmall = "nn-37f18f62d772.nnue";
 
 std::string trim(std::string value) {
   const auto begin = value.find_first_not_of(" \t\r\n");

--- a/test/engine_tests.cpp
+++ b/test/engine_tests.cpp
@@ -44,7 +44,7 @@ int main() {
     const auto original_engine_dir = g_engine_dir;
     const fs::path temp_root = fs::temp_directory_path() / "sirio_nnue_option_test";
     const fs::path resources_dir = temp_root / "resources";
-    const fs::path nnue_file = resources_dir / "sirio_default.nnue";
+    const fs::path nnue_file = resources_dir / "nn-1c0000000000.nnue";
     fs::create_directories(resources_dir);
     {
         std::ofstream out(nnue_file);
@@ -61,12 +61,12 @@ int main() {
     OptionsMap.set("EvalFile", "<empty>");
     expect(OptionsMap.at("EvalFile").s.empty(), "EvalFile <empty> should clear the string");
 
-    OptionsMap.set("EvalFile", "<sirio_default.nnue>");
-    expect(OptionsMap.at("EvalFile").s == "sirio_default.nnue",
+    OptionsMap.set("EvalFile", "<nn-1c0000000000.nnue>");
+    expect(OptionsMap.at("EvalFile").s == "nn-1c0000000000.nnue",
            "EvalFile should strip angle brackets");
 
-    OptionsMap.set("EvalFile", "<  sirio_default.nnue >");
-    expect(OptionsMap.at("EvalFile").s == "sirio_default.nnue",
+    OptionsMap.set("EvalFile", "<  nn-1c0000000000.nnue >");
+    expect(OptionsMap.at("EvalFile").s == "nn-1c0000000000.nnue",
            "EvalFile should trim whitespace around values");
 
     const auto resolved = uci::resolve_nnue_path_for_tests(OptionsMap.at("EvalFile").s);


### PR DESCRIPTION
## Summary
- switch the engine defaults to the Stockfish `nn-1c0000000000.nnue` and `nn-37f18f62d772.nnue` networks so they are auto-detected like in Revolution
- refresh the download script and documentation to point at the new network names and URLs
- adjust the NNUE option regression test to track the updated defaults

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68de91e4141c83278fb52fc216cd088f