### PR TITLE
Handle CLI parsing without exceptions

### DIFF
--- a/src/files/fen.h
+++ b/src/files/fen.h
@@ -2,10 +2,13 @@
 
 #include "pyrrhic/board.h"
 
+#include <optional>
 #include <string>
 
 namespace sirio::files {
 
+std::optional<pyrrhic::Board> try_parse_fen(const std::string& fen,
+                                            std::string* error_message = nullptr);
 pyrrhic::Board parse_fen(const std::string& fen);
 std::string to_fen(const pyrrhic::Board& board);
 

--- a/src/files/pgn_loader.h
+++ b/src/files/pgn_loader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -13,6 +14,8 @@ struct PgnGame {
 };
 
 PgnGame load_pgn(const std::string& content);
+std::optional<PgnGame> try_load_pgn_from_file(const std::string& path,
+                                              std::string* error_message = nullptr);
 PgnGame load_pgn_from_file(const std::string& path);
 
 }  // namespace sirio::files


### PR DESCRIPTION
## Summary
- add optional FEN parsing helpers that work without relying on C++ exceptions
- provide a non-throwing PGN loader path and use it when the CLI is built without exceptions
- update the CLI entry points to fall back to the new helpers when exceptions are disabled

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68de9c6da35c8327af1fb9c06cd6ef7e