### PR TITLE
Resolve NNUE paths relative to executable and stabilize bench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ set(SIRIOC_C_ENGINE_SOURCES
     src/transposition.c
     src/uci.c
     src/util.c
+    src/util/path.cpp
     src/nn/accumulator.c
     src/nn/evaluate.c
     src/zobrist.cpp

--- a/src/eval.c
+++ b/src/eval.c
@@ -121,7 +121,6 @@ static int load_legacy_material_weights(sirio_nn_model* model, const char* path)
         return 0;
     }
 
-    printf("info string Loaded legacy material weights from %s\n", path);
     return 1;
 }
 
@@ -325,11 +324,7 @@ int eval_load_network(const char* path) {
     if (!path || !*path) {
         return 0;
     }
-    int ok = sirio_nn_model_load(&g_eval_model, path);
-    if (ok) {
-        printf("info string Primary NNUE network loaded from %s\n", path);
-    }
-    return ok;
+    return sirio_nn_model_load(&g_eval_model, path);
 }
 
 int eval_load_network_from_buffer(const void* data, size_t size) {
@@ -349,14 +344,9 @@ int eval_load_small_network(const char* path) {
     if (!path || !*path) {
         sirio_nn_model_free(&g_small_model);
         sirio_nn_model_init(&g_small_model);
-        printf("info string Secondary NNUE network cleared\n");
         return 1;
     }
-    int ok = sirio_nn_model_load(&g_small_model, path);
-    if (ok) {
-        printf("info string Secondary NNUE network loaded from %s\n", path);
-    }
-    return ok;
+    return sirio_nn_model_load(&g_small_model, path);
 }
 
 void eval_set_use_nnue(bool use_nnue) {

--- a/src/util/path.cpp
+++ b/src/util/path.cpp
@@ -1,0 +1,134 @@
+#include "util/path.h"
+
+#include <system_error>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <sys/types.h>
+#endif
+
+namespace {
+namespace fs = std::filesystem;
+
+fs::path canonical_or_empty(const fs::path& p) {
+  std::error_code ec;
+  fs::path canonical = fs::canonical(p, ec);
+  if (ec) {
+    canonical = fs::weakly_canonical(p, ec);
+  }
+  if (ec) {
+    canonical = fs::absolute(p, ec);
+  }
+  if (ec) {
+    return {};
+  }
+  return canonical;
+}
+
+bool exists_file(const fs::path& p) {
+  std::error_code ec;
+  return fs::is_regular_file(p, ec);
+}
+
+}  // namespace
+
+namespace util {
+
+fs::path exe_dir() {
+#ifdef _WIN32
+  char buf[MAX_PATH] = {0};
+  DWORD len = GetModuleFileNameA(nullptr, buf, MAX_PATH);
+  if (len == 0 || len >= MAX_PATH) {
+    std::error_code ec;
+    return fs::current_path(ec);
+  }
+  fs::path exe_path(buf);
+  fs::path canon = canonical_or_empty(exe_path);
+  if (canon.empty()) {
+    return exe_path.parent_path();
+  }
+  return canon.parent_path();
+#else
+  char buf[4096] = {0};
+  ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (n > 0 && n < static_cast<ssize_t>(sizeof(buf))) {
+    buf[n] = '\0';
+    fs::path exe_path(buf);
+    fs::path canon = canonical_or_empty(exe_path);
+    if (!canon.empty()) {
+      return canon.parent_path();
+    }
+    return exe_path.parent_path();
+  }
+  std::error_code ec;
+  return fs::current_path(ec);
+#endif
+}
+
+fs::path resolve_resource(const std::string& relOrAbs) {
+  if (relOrAbs.empty()) {
+    return {};
+  }
+
+  fs::path candidate(relOrAbs);
+  if (exists_file(candidate)) {
+    return canonical_or_empty(candidate);
+  }
+
+  const fs::path base = exe_dir();
+  const fs::path base_candidates[] = {
+      base / relOrAbs,
+      base / ".." / relOrAbs,
+  };
+
+  for (const fs::path& try_path : base_candidates) {
+    if (exists_file(try_path)) {
+      return canonical_or_empty(try_path);
+    }
+  }
+
+  std::error_code cwd_ec;
+  fs::path cwd = fs::current_path(cwd_ec);
+  if (!cwd_ec) {
+    fs::path cwd_candidate = cwd / relOrAbs;
+    if (exists_file(cwd_candidate)) {
+      return canonical_or_empty(cwd_candidate);
+    }
+  }
+
+  return {};
+}
+
+}  // namespace util
+
+extern "C" {
+
+const char* util_exe_dir_cstr(void) {
+  thread_local std::string storage;
+  storage.clear();
+  auto dir = util::exe_dir();
+  if (dir.empty()) {
+    return nullptr;
+  }
+  storage = dir.string();
+  return storage.c_str();
+}
+
+const char* util_resolve_resource_cstr(const char* rel_or_abs) {
+  if (!rel_or_abs || !*rel_or_abs) {
+    return nullptr;
+  }
+  thread_local std::string storage;
+  storage.clear();
+  auto resolved = util::resolve_resource(rel_or_abs);
+  if (resolved.empty()) {
+    return nullptr;
+  }
+  storage = resolved.string();
+  return storage.c_str();
+}
+
+}  // extern "C"
+

--- a/src/util/path.h
+++ b/src/util/path.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef __cplusplus
+#include <filesystem>
+#include <string>
+
+namespace util {
+std::filesystem::path exe_dir();
+std::filesystem::path resolve_resource(const std::string& relOrAbs);
+}  // namespace util
+
+extern "C" {
+#endif
+
+const char* util_exe_dir_cstr(void);
+const char* util_resolve_resource_cstr(const char* rel_or_abs);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+


### PR DESCRIPTION
## Summary
- add a filesystem-based resolver for resources relative to the executable and make it available to the C engine
- load NNUE networks through the resolver during option changes, UCI startup, and bench runs while tightening bench output and logging
- strengthen aspiration handling in iterative deepening to avoid stalls and ensure depth reductions stay non-negative

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68dea055d82c8327a46a9f3a5ce1bb7a