### PR TITLE
Document nested device source hierarchy

### DIFF
--- a/device/src/fathom/src/README.md
+++ b/device/src/fathom/src/README.md
@@ -1,0 +1,7 @@
+# Fathom Device Source
+
+This directory holds the nested `device/src/fathom/src` hierarchy requested for the device module structure.
+
+- `device/src`: top-level device source directory.
+- `device/src/fathom`: module for Fathom-specific code.
+- `device/src/fathom/src`: inner source folder for implementation files.


### PR DESCRIPTION
## Summary
- replace the placeholder file with a README in `device/src/fathom/src`
- document the expected nested `device/src/fathom/src` hierarchy for the device module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dec3d5f1b48327b82fadbbb7edf5b2