### PR TITLE
Rename engine to SirioC and update credits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifeq ($(OS),Windows_NT)
-	EXE := Obsidian.exe
+        EXE := SirioC.exe
 else
-	EXE := Obsidian
+        EXE := SirioC
 endif
 
 DEFAULT_NET = net89perm.bin
@@ -72,17 +72,17 @@ endif
 	gcc $(FLAGS) -c $< -o $@
 
 make: download-net $(FILES)
-	g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-generate="obs_pgo"
+        g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-generate="sirio_pgo"
 ifeq ($(OS),Windows_NT)
-	$(EXE) bench
+        $(EXE) bench
 else
-	./$(EXE) bench
+        ./$(EXE) bench
 endif
-	g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-use="obs_pgo"
+        g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-use="sirio_pgo"
 ifeq ($(OS),Windows_NT)
-	powershell.exe -Command "Remove-Item -Recurse -Force obs_pgo"
+        powershell.exe -Command "Remove-Item -Recurse -Force sirio_pgo"
 else
-	rm -rf obs_pgo
+        rm -rf sirio_pgo
 endif
 
 nopgo: download-net $(OBJS)
@@ -97,6 +97,6 @@ ifdef DOWNLOAD_NET
 		echo "File $(EVALFILE) already exists, skipping download."; \
 	else \
 		echo Downloading net; \
-		curl -sOL https://github.com/gab8192/Obsidian-nets/releases/download/nets/$(EVALFILE); \
-	fi
+                curl -sOL https://github.com/gab8192/SirioC-nets/releases/download/nets/$(EVALFILE); \
+        fi
 endif

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Obsidian
-A top tier UCI chess engine written in c++, that I started developing in april 2023.
+# SirioC
+A top tier UCI chess engine written in c++, that I started developing in April 2023.
 
-As of 18 July 2024, Obsidian is the 3rd strongest engine at 10+1s, after Stockfish and Torch.
+As of 18 July 2024, SirioC is the 3rd strongest engine at 10+1s, after Stockfish and Torch.
 January 2025: It is 3rd in SPCC too.
 
 
 ## Building
 ```
-git clone https://github.com/gab8192/Obsidian
-cd Obsidian
+git clone https://github.com/gab8192/SirioC
+cd SirioC
 make -j nopgo build=ARCH
 ```
 ARCH choice: native, sse2, ssse3, avx2, avx2-pext, avx512. `native` is recommended however.
@@ -16,11 +16,12 @@ You can remove the `nopgo` flag to enable profile guided optimization.
 
 
 ## Neural network
-Obsidian evaluates positions with a neural network trained on Lc0 data.
+SirioC evaluates positions with a neural network trained on Lc0 data.
 
 
 ## Credits
+* Credits to Codex Chatgpt for ongoing development support.
 * To Styxdoto (or Styx), he has an incredible machine with 128 threads and he has donated CPU time
 * To Witek902, for letting me in his OpenBench instance, allowing me to use massive hardware for my tests
-* To fireandice, for training the neural network of Obsidian 9.0
-* The neural network of obsidian is trained with https://github.com/jw1912/bullet
+* To fireandice, for training the neural network of SirioC 9.0
+* The neural network of SirioC is trained with https://github.com/jw1912/bullet

--- a/device/Makefile
+++ b/device/Makefile
@@ -1,7 +1,7 @@
 ifeq ($(OS),Windows_NT)
-	EXE := Obsidian.exe
+        EXE := SirioC.exe
 else
-	EXE := Obsidian
+        EXE := SirioC
 endif
 
 DEFAULT_NET = net89perm.bin
@@ -72,17 +72,17 @@ endif
 	gcc $(FLAGS) -c $< -o $@
 
 make: download-net $(FILES)
-	g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-generate="obs_pgo"
+        g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-generate="sirio_pgo"
 ifeq ($(OS),Windows_NT)
-	$(EXE) bench
+        $(EXE) bench
 else
-	./$(EXE) bench
+        ./$(EXE) bench
 endif
-	g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-use="obs_pgo"
+        g++ $(FLAGS) $(FILES) -o $(EXE) -fprofile-use="sirio_pgo"
 ifeq ($(OS),Windows_NT)
-	powershell.exe -Command "Remove-Item -Recurse -Force obs_pgo"
+        powershell.exe -Command "Remove-Item -Recurse -Force sirio_pgo"
 else
-	rm -rf obs_pgo
+        rm -rf sirio_pgo
 endif
 
 nopgo: download-net $(OBJS)
@@ -97,6 +97,6 @@ ifdef DOWNLOAD_NET
 		echo "File $(EVALFILE) already exists, skipping download."; \
 	else \
 		echo Downloading net; \
-		curl -sOL https://github.com/gab8192/Obsidian-nets/releases/download/nets/$(EVALFILE); \
-	fi
+                curl -sOL https://github.com/gab8192/SirioC-nets/releases/download/nets/$(EVALFILE); \
+        fi
 endif

--- a/device/README.md
+++ b/device/README.md
@@ -1,14 +1,14 @@
-# Obsidian
-A top tier UCI chess engine written in c++, that I started developing in april 2023.
+# SirioC
+A top tier UCI chess engine written in c++, that I started developing in April 2023.
 
-As of 18 July 2024, Obsidian is the 3rd strongest engine at 10+1s, after Stockfish and Torch.
+As of 18 July 2024, SirioC is the 3rd strongest engine at 10+1s, after Stockfish and Torch.
 January 2025: It is 3rd in SPCC too.
 
 
 ## Building
 ```
-git clone https://github.com/gab8192/Obsidian
-cd Obsidian
+git clone https://github.com/gab8192/SirioC
+cd SirioC
 make -j nopgo build=ARCH
 ```
 ARCH choice: native, sse2, ssse3, avx2, avx2-pext, avx512. `native` is recommended however.
@@ -16,11 +16,12 @@ You can remove the `nopgo` flag to enable profile guided optimization.
 
 
 ## Neural network
-Obsidian evaluates positions with a neural network trained on Lc0 data.
+SirioC evaluates positions with a neural network trained on Lc0 data.
 
 
 ## Credits
+* Credits to Codex Chatgpt for ongoing development support.
 * To Styxdoto (or Styx), he has an incredible machine with 128 threads and he has donated CPU time
 * To Witek902, for letting me in his OpenBench instance, allowing me to use massive hardware for my tests
-* To fireandice, for training the neural network of Obsidian 9.0
-* The neural network of obsidian is trained with https://github.com/jw1912/bullet
+* To fireandice, for training the neural network of SirioC 9.0
+* The neural network of SirioC is trained with https://github.com/jw1912/bullet

--- a/device/src/main.cpp
+++ b/device/src/main.cpp
@@ -1,4 +1,4 @@
-// Obsidian.cpp : This file contains the 'main' function. Program execution begins and ends there.
+// SirioC.cpp : This file contains the 'main' function. Program execution begins and ends there.
 //
 
 #include "cuckoo.h"
@@ -13,7 +13,7 @@
 
 int main(int argc, char** argv)
 {
-  std::cout << "Obsidian " << engineVersion << " by Gabriele Lombardo" << std::endl;
+  std::cout << "SirioC " << engineVersion << " by Codex Chatgpt" << std::endl;
 
   Zobrist::init();
 

--- a/device/src/uci.cpp
+++ b/device/src/uci.cpp
@@ -254,8 +254,8 @@ void UCI::loop(int argc, char* argv[]) {
     }
 
     else if (token == "uci") {
-      std::cout << "id name Obsidian " << engineVersion
-        << "\nid author Gabriele Lombardo"
+      std::cout << "id name SirioC " << engineVersion
+        << "\nid author Codex Chatgpt"
         << Options
         << "\n" << paramsToUci()
         << "uciok" << std::endl;


### PR DESCRIPTION
## Summary
- rename all Obsidian references to SirioC across documentation, build scripts, and runtime banners
- update author attribution to credit Codex Chatgpt throughout the UCI interface and README files
- adjust build artifacts and network download paths to use the SirioC naming convention

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec82b26d08327a0fe30830ba78a51