### PR TITLE
Rename Obsidian references to SirioC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// Obsidian.cpp : This file contains the 'main' function. Program execution begins and ends there.
+// SirioC.cpp : This file contains the 'main' function. Program execution begins and ends there.
 //
 
 #include "cuckoo.h"
@@ -13,7 +13,7 @@
 
 int main(int argc, char** argv)
 {
-  std::cout << "Obsidian " << engineVersion << " by Gabriele Lombardo" << std::endl;
+  std::cout << "SirioC " << engineVersion << " by Gabriele Lombardo" << std::endl;
 
   Zobrist::init();
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -254,7 +254,7 @@ void UCI::loop(int argc, char* argv[]) {
     }
 
     else if (token == "uci") {
-      std::cout << "id name Obsidian " << engineVersion
+      std::cout << "id name SirioC " << engineVersion
         << "\nid author Gabriele Lombardo"
         << Options
         << "\n" << paramsToUci()


### PR DESCRIPTION
## Summary
- update the engine startup banner to print SirioC instead of Obsidian
- report the engine name as SirioC in the UCI identification output

## Testing
- make -n

------
https://chatgpt.com/codex/tasks/task_e_68ded3c42b648327819b83819a305529