### PR TITLE
Add scalar SIMD fallback

### DIFF
--- a/src/simd.h
+++ b/src/simd.h
@@ -197,6 +197,196 @@ namespace SIMD {
     return _mm_cvtss_f32(sum_32);
   }
 
+#else
+
+  struct alignas(16) VecI {
+    union {
+      int32_t i32[4];
+      uint32_t u32[4];
+      int16_t i16[8];
+      uint16_t u16[8];
+      int8_t i8[16];
+      uint8_t u8[16];
+    };
+  };
+
+  struct alignas(16) VecF {
+    float f[4];
+  };
+
+  constexpr int PackusOrder[2] = {0, 1};
+
+  inline VecI setzeroSi() { return VecI{}; }
+
+  inline VecF setzeroPs() { return VecF{}; }
+
+  inline VecI addEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = static_cast<int16_t>(x.i16[i] + y.i16[i]);
+    return r;
+  }
+
+  inline VecI addEpi32(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 4; ++i)
+      r.i32[i] = x.i32[i] + y.i32[i];
+    return r;
+  }
+
+  inline VecF addPs(VecF x, VecF y) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = x.f[i] + y.f[i];
+    return r;
+  }
+
+  inline VecI subEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = static_cast<int16_t>(x.i16[i] - y.i16[i]);
+    return r;
+  }
+
+  inline VecI minEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = std::min(x.i16[i], y.i16[i]);
+    return r;
+  }
+
+  inline VecI maxEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = std::max(x.i16[i], y.i16[i]);
+    return r;
+  }
+
+  inline VecI mulloEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = static_cast<int16_t>(x.i16[i] * y.i16[i]);
+    return r;
+  }
+
+  inline VecI mulhiEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = static_cast<int16_t>((static_cast<int32_t>(x.i16[i]) *
+                                       static_cast<int32_t>(y.i16[i])) >> 16);
+    return r;
+  }
+
+  inline VecI maddEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 4; ++i) {
+      int idx = i * 2;
+      r.i32[i] = static_cast<int32_t>(x.i16[idx]) * y.i16[idx] +
+                  static_cast<int32_t>(x.i16[idx + 1]) * y.i16[idx + 1];
+    }
+    return r;
+  }
+
+  inline VecI maddubsEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i) {
+      int idx = i * 2;
+      int sum = static_cast<int>(x.u8[idx]) * static_cast<int>(y.i8[idx]) +
+                static_cast<int>(x.u8[idx + 1]) * static_cast<int>(y.i8[idx + 1]);
+      r.i16[i] = static_cast<int16_t>(sum);
+    }
+    return r;
+  }
+
+  inline VecI set1Epi16(int16_t x) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = x;
+    return r;
+  }
+
+  inline VecI set1Epi32(int x) {
+    VecI r{};
+    for (int i = 0; i < 4; ++i)
+      r.i32[i] = x;
+    return r;
+  }
+
+  inline VecI slliEpi16(VecI x, int y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i)
+      r.i16[i] = static_cast<int16_t>(x.i16[i] << y);
+    return r;
+  }
+
+  inline VecI packusEpi16(VecI x, VecI y) {
+    VecI r{};
+    for (int i = 0; i < 8; ++i) {
+      int xv = x.i16[i];
+      int yv = y.i16[i];
+      r.u8[i] = static_cast<uint8_t>(std::clamp(xv, 0, 255));
+      r.u8[i + 8] = static_cast<uint8_t>(std::clamp(yv, 0, 255));
+    }
+    return r;
+  }
+
+  inline uint8_t getNnzMask(VecI x) {
+    uint8_t mask = 0;
+    for (int i = 0; i < 4; ++i)
+      if (x.i32[i] > 0)
+        mask |= static_cast<uint8_t>(1u << i);
+    return mask;
+  }
+
+  inline VecF set1Ps(float x) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = x;
+    return r;
+  }
+
+  inline VecF minPs(VecF x, VecF y) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = std::min(x.f[i], y.f[i]);
+    return r;
+  }
+
+  inline VecF maxPs(VecF x, VecF y) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = std::max(x.f[i], y.f[i]);
+    return r;
+  }
+
+  inline VecF mulPs(VecF x, VecF y) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = x.f[i] * y.f[i];
+    return r;
+  }
+
+  inline VecF mulAddPs(VecF x, VecF y, VecF z) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = x.f[i] * y.f[i] + z.f[i];
+    return r;
+  }
+
+  inline VecF castEpi32ToPs(VecI x) {
+    VecF r{};
+    for (int i = 0; i < 4; ++i)
+      r.f[i] = static_cast<float>(x.i32[i]);
+    return r;
+  }
+
+  inline float reduceAddPs(VecF vec) {
+    float sum = 0.0f;
+    for (float v : vec.f)
+      sum += v;
+    return sum;
+  }
+
 #endif
 
   constexpr int Alignment = sizeof(VecI);


### PR DESCRIPTION
## Summary
- add scalar implementations for the SIMD abstraction when no vector ISA macros are available
- provide scalar versions of the key vector operations so NNUE evaluation still works without AVX/SSSE3 support

## Testing
- make build=x86-64-sse41-popcnt CC=clang CXX=clang++ LDFLAGS='-fuse-ld=lld' nopgo

------
https://chatgpt.com/codex/tasks/task_e_68ded48a50e483279bca30f0404633e0