### PR TITLE
Handle clang -flto compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,24 @@ FILES = $(wildcard src/*.cpp) src/fathom/src/tbprobe.c
 OBJS = $(FILES:.cpp=.o)
 OBJS := $(OBJS:.c=.o)
 
-OPTIMIZE = -O3 -fno-stack-protector -fno-math-errno -funroll-loops -fno-exceptions -flto -flto-partition=one
+OPTIMIZE = -O3 -fno-stack-protector -fno-math-errno -funroll-loops -fno-exceptions -flto
 
 COMMON_FLAGS = -s -pthread -DNDEBUG -DEvalFile=\"$(EVALFILE)\" $(OPTIMIZE)
 
 CXXFLAGS += -std=c++17 $(COMMON_FLAGS)
 CFLAGS += $(COMMON_FLAGS)
+
+CXX_LTO_PARTITION = -flto-partition=one
+ifneq ($(filter clang%,$(notdir $(CXX))),)
+    CXX_LTO_PARTITION =
+endif
+CXXFLAGS += $(CXX_LTO_PARTITION)
+
+C_LTO_PARTITION = -flto-partition=one
+ifneq ($(filter clang%,$(notdir $(CC))),)
+    C_LTO_PARTITION =
+endif
+CFLAGS += $(C_LTO_PARTITION)
 
 ifeq ($(OS),Windows_NT)
     CXXFLAGS += -static


### PR DESCRIPTION
## Summary
- stop adding -flto-partition=one to every build by default
- conditionally apply the partition flag for the C and C++ compilers only when they are not clang-based

## Testing
- make build=x86-64-sse41-popcnt nopgo

------
https://chatgpt.com/codex/tasks/task_e_68ded889dd7483278435993f5cffa5d8