### PR TITLE
Fix assignment warnings in move loops

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -570,7 +570,7 @@ namespace Search {
     // Visit moves
     Move move;
 
-    while (move = movePicker.nextMove(false)) {
+    while ((move = movePicker.nextMove(false))) {
 
       TT::prefetch(pos.keyAfter(move));
 
@@ -910,7 +910,7 @@ namespace Search {
 
       Move move;
 
-      while (move = pcMovePicker.nextMove(false)) {
+      while ((move = pcMovePicker.nextMove(false))) {
 
         TT::prefetch(pos.keyAfter(move));
 
@@ -969,7 +969,7 @@ namespace Search {
 
     Move move;
 
-    while (move = movePicker.nextMove(skipQuiets)) {
+    while ((move = movePicker.nextMove(skipQuiets))) {
       if (move == excludedMove)
         continue;
 


### PR DESCRIPTION
## Summary
- wrap move picker assignments in parentheses to avoid warning about assignment used as condition

## Testing
- make build=native nopgo

------
https://chatgpt.com/codex/tasks/task_e_68deda2d4f6c8327af2a0b427ca371bd