### PR TITLE
Update branding to SirioC 1.0 and improve NNUE guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SirioC
-A top tier UCI chess engine written in C++ that I started developing in April 2023.
+SirioC 1.0 is a top tier UCI chess engine written in C++ and currently maintained by Jorge Ruiz with credits to Codex ChatGPT.
 
 You can find the latest news, binaries and documentation on the official website: <https://ijccrl.com>.
 
@@ -20,9 +20,11 @@ You can remove the `nopgo` flag to enable profile guided optimization.
 ## Neural network
 SirioC evaluates positions with a neural network trained on Lc0 data using the fastchess training framework.
 
+If the engine prints `info string NNUE: no network found`, download the default weights with `make download-net` or place the requested `.nnue/.bin` file (default: `net89perm.bin`) next to the executable and/or set the `EvalFile` UCI option. Running the engine without weights falls back to a simple material evaluation and bench performance will be noticeably slower.
+
 
 ## Credits
-* Credits to Codex ChatGPT and to the anonymous users who test the engine on their hardware.
+* Jorge Ruiz and Codex ChatGPT for the current maintenance and guidance of the engine.
 * To Styxdoto (or Styx), he has an incredible machine with 128 threads and he has donated CPU time
 * To Witek902, for letting me in his OpenBench instance, allowing me to use massive hardware for my tests
 * To fireandice, for training the neural network of SirioC 9.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
   std::fprintf(stderr, "info string CPU features: %s\n", cpu.toString().c_str());
   requireSupportedOrExit(cpu);
 
-  std::cout << "SirioC " << engineVersion << " by Gabriele Lombardo" << std::endl;
+  std::cout << "SirioC " << engineVersion << " by Jorge Ruiz (credits: Codex ChatGPT)" << std::endl;
 
   Zobrist::init();
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -207,6 +207,9 @@ namespace NNUE {
     }
   }
 
+  bool usingMaterialFallback() {
+    return useMaterialFallback;
+  }
 
   bool needRefresh(Color side, Square oldKing, Square newKing) {
     // Crossed half?
@@ -418,6 +421,8 @@ namespace NNUE {
       }
       useMaterialFallback = true;
       std::fprintf(stderr, "info string NNUE: no network found; using material eval.\n");
+      if (std::strlen(EvalFile))
+        std::fprintf(stderr, "info string NNUE: place %s next to the executable or set the EvalFile option.\n", EvalFile);
     }
   }
 

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -85,4 +85,6 @@ namespace NNUE {
   void loadWeights();
 
   Score evaluate(Position& pos, Accumulator& accumulator);
+
+  bool usingMaterialFallback();
 }

--- a/src/types.h
+++ b/src/types.h
@@ -8,7 +8,7 @@
 #include <nmmintrin.h>
 #include <thread>
 
-const std::string engineVersion = "dev-16.15";
+const std::string engineVersion = "1.0";
 
 using Key = uint64_t;
 using Bitboard = uint64_t;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -90,6 +90,10 @@ namespace {
 
     newGame();
 
+    if (NNUE::usingMaterialFallback())
+      std::cerr << "info string bench: running without NNUE weights; place '" << EvalFile
+                << "' next to the executable or set the EvalFile option for optimal speed." << std::endl;
+
     for (int i = 0; i < posCount; i++)
     {
       Search::Settings searchSettings;
@@ -273,7 +277,7 @@ void UCI::loop(int argc, char* argv[]) {
 
     else if (token == "uci") {
       std::cout << "id name SirioC " << engineVersion
-        << "\nid author Gabriele Lombardo"
+        << "\nid author Jorge Ruiz (credits: Codex ChatGPT)"
         << Options
         << "\n" << paramsToUci()
         << "uciok" << std::endl;


### PR DESCRIPTION
## Summary
- rename the engine to "SirioC 1.0" and attribute it to Jorge Ruiz with Codex ChatGPT credits across the UCI banner and documentation
- add NNUE fallback detection utilities so bench prints a warning when weights are missing and the loader suggests how to install them
- document how to obtain the default NNUE weights to avoid slow benches when no network is available

## Testing
- make -j2 nopgo build=native

------
https://chatgpt.com/codex/tasks/task_e_68dee705bbb083279c780f51982a254c