### PR TITLE
Update NNUE download to use Stockfish networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ else
         EXE := SirioC
 endif
 
-DEFAULT_NET = net89perm.bin
+DEFAULT_NET = nn-6877cd24400e.nnue
+DOWNLOAD_BASE_URL = https://raw.githubusercontent.com/official-stockfish/networks/master
 
 ifndef EVALFILE
 	EVALFILE = $(DEFAULT_NET)
@@ -148,9 +149,17 @@ clean:
 download-net:
 ifdef DOWNLOAD_NET
 	@if test -f "$(EVALFILE)"; then \
-		echo "File $(EVALFILE) already exists, skipping download."; \
-	else \
-		echo Downloading net; \
-		curl -sOL https://github.com/gab8192/SirioC-nets/releases/download/nets/$(EVALFILE); \
-	fi
+			echo "File $(EVALFILE) already exists, skipping download."; \
+		else \
+			echo "Downloading NNUE network $(notdir $(EVALFILE)) from official Stockfish repository..."; \
+			mkdir -p "$(dir $(EVALFILE))"; \
+			tmp_file="$(EVALFILE).tmp"; \
+			if curl -sSfL -o "$$tmp_file" "$(DOWNLOAD_BASE_URL)/$(notdir $(EVALFILE))"; then \
+				mv "$$tmp_file" "$(EVALFILE)"; \
+			else \
+				rm -f "$$tmp_file"; \
+				echo "Failed to download $(notdir $(EVALFILE)) from $(DOWNLOAD_BASE_URL)"; \
+				exit 1; \
+			fi; \
+		fi
 endif

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can remove the `nopgo` flag to enable profile guided optimization.
 ## Neural network
 SirioC evaluates positions with a neural network trained on Lc0 data using the fastchess training framework.
 
-If the engine prints `info string NNUE: no network found`, download the default weights with `make download-net` or place the requested `.nnue/.bin` file (default: `net89perm.bin`) next to the executable and/or set the `EvalFile` UCI option. Running the engine without weights falls back to a simple material evaluation and bench performance will be noticeably slower.
+If the engine prints `info string NNUE: no network found`, download the default weights with `make download-net` or place the requested `.nnue/.bin` file (default: `nn-6877cd24400e.nnue`) next to the executable and/or set the `EvalFile` UCI option. The `make download-net` helper fetches networks from the [official Stockfish networks repository](https://github.com/official-stockfish/networks), so you can override `EVALFILE` to any other filename published there. Running the engine without weights falls back to a simple material evaluation and bench performance will be noticeably slower.
 
 
 ## Credits


### PR DESCRIPTION
## Summary
- set the default NNUE weights to the official Stockfish network `nn-6877cd24400e.nnue`
- download networks from the Stockfish `official-stockfish/networks` repository with basic error handling
- document the new default network name and source of downloadable weights in the README

## Testing
- make download-net

------
https://chatgpt.com/codex/tasks/task_e_68deecdc8b3483278048736533485858