### PR TITLE
Rename Windows binary and adjust benchmark defaults

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -148,6 +148,6 @@ if [ -z "$file_arch" ]; then
   file_arch=$true_arch
 fi
 
-file_name="stockfish-$file_os-$file_arch.$file_ext"
+file_name="sirioc-$file_os-$file_arch.$file_ext"
 
 printf '%s %s\n' "$true_arch" "$file_name"

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-	EXE = stockfish.exe
+    EXE = Sirioc\ 1.0.exe
 else
-	EXE = stockfish
+    EXE = Sirioc
 endif
 
 ### Installation dir definitions
@@ -49,7 +49,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(WINE_PATH) ./$(EXE) bench
+PGOBENCH = $(WINE_PATH) "./$(EXE)" bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
@@ -217,8 +217,8 @@ ifeq ($(findstring -sse41,$(ARCH)),-sse41)
 endif
 
 ifeq ($(findstring -modern,$(ARCH)),-modern)
-        $(warning *** ARCH=$(ARCH) is deprecated, defaulting to ARCH=x86-64-sse41-popcnt. Execute `make help` for a list of available architectures. ***)
-        $(shell sleep 5)
+	$(warning *** ARCH=$(ARCH) is deprecated, defaulting to ARCH=x86-64-sse41-popcnt. Execute `make help` for a list of available architectures. ***)
+	$(shell sleep 5)
 	popcnt = yes
 	sse = yes
 	sse2 = yes
@@ -853,7 +853,7 @@ endif
 
 help:
 	@echo "" && \
-	echo "To compile stockfish, type: " && \
+	echo "To compile Sirioc, type: " && \
 	echo "" && \
 	echo "make -j target [ARCH=arch] [COMP=compiler] [COMPCXX=cxx]" && \
 	echo "" && \
@@ -970,16 +970,17 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@rm -f Sirioc Sirioc\ 1.0.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
+
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f stockfish.profdata *.profraw
-	@rm -f stockfish.*args*
-	@rm -f stockfish.*lt*
-	@rm -f stockfish.res
+	@rm -f sirioc.profdata *.profraw
+	@rm -f sirioc.*args*
+	@rm -f sirioc.*lt*
+	@rm -f sirioc.res
 	@rm -f ./-lstdc++.res
 
 # evaluation network (nnue)
@@ -1081,9 +1082,9 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
+	$(XCRUN) llvm-profdata merge -output=sirioc.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
+	EXTRACXXFLAGS='-fprofile-use=sirioc.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
@@ -1109,9 +1110,9 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) llvm-profdata merge -output=stockfish.profdata *.profraw
+	$(XCRUN) llvm-profdata merge -output=sirioc.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRACXXFLAGS='-fprofile-instr-use=sirioc.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -19,6 +19,7 @@
 #include "benchmark.h"
 #include "numa.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -450,7 +451,7 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
     int desiredTimeS;
 
     if (!(is >> setup.threads))
-        setup.threads = get_hardware_concurrency();
+        setup.threads = std::max<int>(1, static_cast<int>(get_hardware_concurrency()));
     else
         setup.originalInvocation += std::to_string(setup.threads);
 
@@ -509,4 +510,4 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
     return setup;
 }
 
-}  // namespace Stockfish
+}  // namespace Stockfish::Benchmark

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -19,7 +19,7 @@ cat << 'EOF' > $EXPECT_SCRIPT
 set timeout 30
 lassign [lrange $argv 0 4] pos depth result chess960 logfile
 log_file -noappend $logfile
-spawn ./stockfish
+spawn ./Sirioc
 if {$chess960 == "true"} {
   send "setoption name UCI_Chess960 value true\n"
 }

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -15,7 +15,7 @@ echo "reprosearch testing started"
 # the same node count for each iteration.
 cat << EOF > repeat.exp
  set timeout 10
- spawn ./stockfish
+ spawn ./Sirioc
  lassign \$argv nodes
 
  send "uci\n"

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 
 # obtain
 
-signature=`eval "$WINE_PATH ./stockfish bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
+signature=`eval "$WINE_PATH ./Sirioc bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
 
 if [ $# -gt 0 ]; then
    # compare to given reference


### PR DESCRIPTION
## Summary
- rename the produced executables and helper scripts from Stockfish to Sirioc, including Windows builds and automation utilities
- quote executable usage in make targets and adjust cleanup/profile steps to match the new naming
- clamp benchmark thread detection to at least one thread to avoid undersized runs and include the needed algorithm header
- update test scripts and native artifact naming to reference the Sirioc binary

## Testing
- make build ARCH=x86-64

------
https://chatgpt.com/codex/tasks/task_e_68e0d8cf19448327ba9372c66e759bb7